### PR TITLE
ci: Initial config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,56 @@
+---
+name: Go
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          cache: true
+
+      - name: Format
+        run: |
+          OUT="$(gofmt -d -e -s . 2>&1)"
+          if [ "$OUT" != "" ]; then
+            echo "$OUT"
+            exit 1
+          fi
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          cache: true
+
+      - name: Build
+        run: go build -v ./...
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          cache: true
+
+      - name: Test
+        run: go test -v -race ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: default
+default: fmt test lint
+
+.PHONY: fmt
+fmt:
+	gofmt -d -e -s .
+
+.PHONY: test
+test:
+	go test -v -race ./...
+
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+.PHONY: lint-docker
+lint-docker:
+	docker run -t --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.50.1 golangci-lint run

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Note that both the `refs` and `vars` fields are optional, but allow you to contr
 - `refs` will make the test run `k8ify` for each of the provided values. If no `refs` is defined, `k8ify` will be run once for this environment with an empty `ref` value.
 - `vars` can contain environment variables that are ADDED to the ones that are already set within the testing environment. If your compoose file makes use of any environment variables, make sure to add them here for reproducability.
 
-
 To actually run the tests, run `go test` in the root of the repository.
 
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
+	"os"
+
 	"github.com/vshn/k8ify/pkg/converter"
-	"io/ioutil"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -15,17 +16,17 @@ type Config struct {
 }
 
 func ReadConfig(fileName string) Config {
-	buf, err := ioutil.ReadFile(fileName)
+	buf, err := os.ReadFile(fileName)
 	if err != nil {
 		return Config{}
 	}
 
-	config := &Config{}
-	yaml.Unmarshal(buf, config)
-	if err != nil {
+	config := Config{}
+	if err := yaml.Unmarshal(buf, &config); err != nil {
 		return Config{}
 	}
-	return *config
+
+	return config
 }
 
 func ConfigMerge(configs ...Config) Config {

--- a/internal/output.go
+++ b/internal/output.go
@@ -1,15 +1,15 @@
 package internal
 
 import (
-	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
-	"log"
-	"os"
-	"strings"
 )
 
 func prepareOutputDir(outputDir string) error {
@@ -18,7 +18,7 @@ func prepareOutputDir(outputDir string) error {
 		return err
 	}
 
-	files, err := ioutil.ReadDir(outputDir)
+	files, err := os.ReadDir(outputDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -2,6 +2,9 @@ package converter
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	composeTypes "github.com/compose-spec/compose-go/types"
 	"github.com/vshn/k8ify/pkg/util"
 	apps "k8s.io/api/apps/v1"
@@ -10,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strconv"
-	"strings"
 )
 
 func composeServiceStorageToK8s() map[core.ResourceName]resource.Quantity {
@@ -127,7 +128,7 @@ func composeServiceToDeployment(
 		// Env:          envVars,
 		// Reference the secret:
 		EnvFrom: []core.EnvFromSource{
-			core.EnvFromSource{
+			{
 				SecretRef: &core.SecretEnvSource{
 					LocalObjectReference: core.LocalObjectReference{
 						Name: secretName,


### PR DESCRIPTION
Initial CI pipeline

* Jobs run in parallel to speed up
* I added [golangci-lint](https://golangci-lint.run/) - I have made good experiences with it. It already catched two issues (a bug where an error value was not checked, and use of a deprecated Stdlib module).

I have also added a small `Makefile` to run the steps locally