### PR TITLE
Change: Use separate labels for compose-service and sub

### DIFF
--- a/tests/golden/101/manifests/nginx-mpi-deployment.yaml
+++ b/tests/golden/101/manifests/nginx-mpi-deployment.yaml
@@ -3,20 +3,23 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.service: nginx-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: nginx
   name: nginx-mpi
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8ify.service: nginx-mpi
+      k8ify.ref-slug: mpi
+      k8ify.service: nginx
   strategy:
     type: Recreate
   template:
     metadata:
       creationTimestamp: null
       labels:
-        k8ify.service: nginx-mpi
+        k8ify.ref-slug: mpi
+        k8ify.service: nginx
     spec:
       containers:
       - envFrom:

--- a/tests/golden/101/manifests/nginx-mpi-env-secret.yaml
+++ b/tests/golden/101/manifests/nginx-mpi-env-secret.yaml
@@ -4,5 +4,6 @@ kind: Secret
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.service: nginx-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: nginx
   name: nginx-mpi-env

--- a/tests/golden/101/manifests/nginx-mpi-service.yaml
+++ b/tests/golden/101/manifests/nginx-mpi-service.yaml
@@ -4,7 +4,8 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.service: nginx-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: nginx
   name: nginx-mpi
 spec:
   ports:
@@ -12,6 +13,7 @@ spec:
     port: 8080
     targetPort: 80
   selector:
-    k8ify.service: nginx-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: nginx
 status:
   loadBalancer: {}

--- a/tests/golden/demo/manifests/portal-mpi-8001-ingress.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-8001-ingress.yaml
@@ -6,7 +6,8 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-production
   creationTimestamp: null
   labels:
-    k8ify.service: portal-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: portal
   name: portal-mpi-8001
 spec:
   rules:

--- a/tests/golden/demo/manifests/portal-mpi-9001-ingress.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-9001-ingress.yaml
@@ -6,7 +6,8 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-production
   creationTimestamp: null
   labels:
-    k8ify.service: portal-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: portal
   name: portal-mpi-9001
 spec:
   rules:

--- a/tests/golden/demo/manifests/portal-mpi-claim0-persistentvolumeclaim.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-claim0-persistentvolumeclaim.yaml
@@ -4,7 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.service: portal-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: portal
   name: portal-mpi-claim0
 spec:
   accessModes:

--- a/tests/golden/demo/manifests/portal-mpi-deployment.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-deployment.yaml
@@ -4,20 +4,23 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.service: portal-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: portal
   name: portal-mpi
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8ify.service: portal-mpi
+      k8ify.ref-slug: mpi
+      k8ify.service: portal
   strategy:
     type: Recreate
   template:
     metadata:
       creationTimestamp: null
       labels:
-        k8ify.service: portal-mpi
+        k8ify.ref-slug: mpi
+        k8ify.service: portal
     spec:
       containers:
       - envFrom:

--- a/tests/golden/demo/manifests/portal-mpi-env-secret.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-env-secret.yaml
@@ -4,7 +4,8 @@ kind: Secret
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.service: portal-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: portal
   name: portal-mpi-env
 stringData:
   mongodb_database: portal

--- a/tests/golden/demo/manifests/portal-mpi-service.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-service.yaml
@@ -4,7 +4,8 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.service: portal-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: portal
   name: portal-mpi
 spec:
   ports:
@@ -15,6 +16,7 @@ spec:
     port: 9001
     targetPort: 9000
   selector:
-    k8ify.service: portal-mpi
+    k8ify.ref-slug: mpi
+    k8ify.service: portal
 status:
   loadBalancer: {}


### PR DESCRIPTION
Use separate labels for the compose-service name and the "sub" (derived from the ref).

The reason for this is that with a single label it is impossible to correctly find out which part is the compose-service name and which is the sub, e.g. in "portal-foo-bar" the compose-service name could be "portal" (with sub "foo-bar") or "portal-foo" (with sub "bar") or even "portal-foo-bar". Being able to correctly distinguish between compose-service name and sub is important for displaying information in the Web UI.

This change fixes this by using two separate labels. The same labels are used in the K8s service spec as selectors, which should work fine.