### PR TITLE
chore(renovate): Auto-merge patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
   ],
   "ignorePaths": [
-    "**/demo/**"
-  ]
+    "tests/golden/**"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "packageRules": [{
+    "matchUpdateTypes": ["patch"],
+    "matchCurrentVersion": "!/^0/",
+    "automerge": true
+  }]
 }


### PR DESCRIPTION
This will configure Renovate to automatically merge updates that only do lockfile maintenance (updates that do not change the requirements) and patch level updates for versions > v0.x

Also:

- ignore golden-test files
- disable the dependency dashboard