### PR TITLE
feat: Support for liveness/startup/readiness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ A resulting deployment might look like this:
 
 ### Labels
 
-`k8ify` supports configuring services by using compose labels.
+`k8ify` supports configuring services by using compose labels. All labels are optional.
+
+#### General
 
 | Label  | Effect  |
 | ------ | ------- |
@@ -77,6 +79,32 @@ A resulting deployment might look like this:
 | `k8ify.expose: $host`  | The first port is exposed to the internet via a HTTPS ingress with the host name set to `$host`  |
 | `k8ify.expose.$port: $host`  | The port `$port` is exposed to the internet via a HTTPS ingress with the host name set to `$host`  |
 | `k8ify.share-storage: true` | Instead of using a StatefulSet when volumes are detected, use a Deployment that shares the volume between instances. |
+
+#### Health Checks
+
+For each compose service k8ify will set up a basic TCP based health check (liveness and startup) by default.
+For all services providing HTTP endpoints you should provide at least a basic health check path and point `k8ify.liveness` to it.
+This replaces the TCP based health check by a more specific HTTP(S) check.
+
+| Label  | Effect  |
+| ------ | ------- |
+| `k8ify.liveness` | Configure a container liveness check. If the check fails the container will be restarted. |
+| `k8ify.liveness: $path` | Configure the path for a HTTP GET based liveness check. Default is "", which disables the HTTP GET check and uses a simple TCP connection check instead. |
+| `k8ify.liveness.path: $path` | See previous |
+| `k8ify.liveness.enabled: true` | Enable or disable the liveness check. Default is true. |
+| `k8ify.liveness.scheme: 'HTTP'` | Switch to HTTPS for HTTP GET based liveness check. Default is HTTP. |
+| `k8ify.liveness.periodSeconds: 30` | Configure the periodicity of the check. Default is 30. |
+| `k8ify.liveness.timeoutSeconds: 60` | Configure the timeout of the check. Default is 60. |
+| `k8ify.liveness.initialDelaySeconds: 0` | Delay before the first check is executed. Default is 0. |
+| `k8ify.liveness.successThreshold: 1` | Number of times the check needs to succeed in order to signal that everything is fine. Default is 1. |
+| `k8ify.liveness.failureThreshold: 3` | Number of times the check needs to fail in order to signal a failure. Default is 3. |
+| `k8ify.startup` | Configure a container startup check. This puts the liveness check on hold during container startup in order to prevent the liveness check from killing it. |
+| `k8ify.startup.*` | All the settings work the same as for `k8ify.liveness`. **The values are copied over from `k8ify.liveness` by default** with the following exceptions: |
+| `k8ify.startup.periodSeconds: 10` | In order to have quick startup the default is lowered to **10**. |
+| `k8ify.startup.failureThreshold: 30` | In order to give the application a total of 300 seconds to start up, the default is raised to **30**. |
+| `k8ify.readiness` | This check decides if traffic should be sent to this instance or not. In contrast to the liveness check a failing readiness check will not restart the pod, just mark it as unavailable and not send traffic to it. |
+| `k8ify.readiness.*` | All the sub-values work the same as for `k8ify.liveness` incl. defaults. No values are copied over. However the readiness check is disabled by default. |
+| `k8ify.readiness.enabled: false` | Enable or disable the readiness check. Default is false. |
 
 
 ## Conversion

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -124,6 +124,34 @@ spec:
               name: myapp-claim0
             - mountPath: /data
               name: myapp_data
+          # By default both a livenessProbe and startupProbe are set up.
+          # `services.$name.labels["k8ify.liveness"]` and sub-labels
+          livenessProbe:
+            failureThreshold: 3
+            # `httpGet` if `services.$name.labels["k8ify.liveness"]` or `services.$name.labels["k8ify.liveness.path"]` is set, `tcpSocket` otherwise
+            httpGet:
+              # `services.$name.labels["k8ify.liveness"]` or `services.$name.labels["k8ify.liveness.path"]`
+              path: /health
+              # `services.$name.labels["k8ify.liveness.port"]` if it exists, otherwise first containerPort
+              port: 8000
+              # `services.$name.labels["k8ify.liveness.scheme"]`
+              scheme: HTTP
+            # `services.$name.labels["k8ify.liveness.periodSeconds"]`
+            periodSeconds: 30
+            # `services.$name.labels["k8ify.liveness.successThreshold"]`
+            successThreshold: 1
+            # `services.$name.labels["k8ify.liveness.timeoutSeconds"]`
+            timeoutSeconds: 60
+          # `services.$name.labels["k8ify.startup"]` and sub-labels
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 60
       # Values from `services.$name.volumes`, translated as the volumeMounts above
       volumes:
         - name: myapp-claim0
@@ -177,6 +205,34 @@ spec:
               name: myapp-claim0
             - mountPath: /data
               name: myapp_data
+          # By default both a livenessProbe and startupProbe are set up.
+          # `services.$name.labels["k8ify.liveness"]` and sub-labels
+          livenessProbe:
+            failureThreshold: 3
+            # `httpGet` if `services.$name.labels["k8ify.liveness"]` or `services.$name.labels["k8ify.liveness.path"]` is set, `tcpSocket` otherwise
+            httpGet:
+              # `services.$name.labels["k8ify.liveness"]` or `services.$name.labels["k8ify.liveness.path"]`
+              path: /health
+              # `services.$name.labels["k8ify.liveness.port"]` if it exists, otherwise first containerPort
+              port: 8000
+              # `services.$name.labels["k8ify.liveness.scheme"]`
+              scheme: HTTP
+            # `services.$name.labels["k8ify.liveness.periodSeconds"]`
+            periodSeconds: 30
+            # `services.$name.labels["k8ify.liveness.successThreshold"]`
+            successThreshold: 1
+            # `services.$name.labels["k8ify.liveness.timeoutSeconds"]`
+            timeoutSeconds: 60
+          # `services.$name.labels["k8ify.startup"]` and sub-labels
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 60
       # See PersistentVolumeClaim below for how the values are generated.
       volumeTemplates:
         - name: "myapp-claim0"
@@ -312,6 +368,7 @@ services:
   myapp:
     labels:
       k8ify.expose.8001: myapp.example.com
+      k8ify.liveness: /health
     image: docker.io/mycorp/myapp:v0.5.7
     deploy:
       replicas: 2

--- a/pkg/util/stringutils.go
+++ b/pkg/util/stringutils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"crypto/sha512"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -58,6 +59,15 @@ func SubConfig(config map[string]string, prefix string, defaultKey string) map[s
 		}
 	}
 	return subConfig
+}
+
+func ConfigGetInt32(config map[string]string, key string, defaultValue int32) int32 {
+	if valStr, ok := config[key]; ok {
+		if valInt, err := strconv.Atoi(valStr); err == nil {
+			return int32(valInt)
+		}
+	}
+	return defaultValue
 }
 
 func IsTruthy(s string) bool {

--- a/tests/golden/101/manifests/nginx-mpi-deployment.yaml
+++ b/tests/golden/101/manifests/nginx-mpi-deployment.yaml
@@ -25,9 +25,23 @@ spec:
         - secretRef:
             name: nginx-mpi-env
         image: docker.io/library/nginx
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
         name: nginx-mpi
         ports:
         - containerPort: 80
         resources: {}
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
       restartPolicy: Always
 status: {}

--- a/tests/golden/demo/docker-compose-prod.yml
+++ b/tests/golden/demo/docker-compose-prod.yml
@@ -8,6 +8,15 @@ services:
       k8ify.expose.8001: 'portal-k8ify.apps.cloudscale-lpg-2.appuio.cloud'
       k8ify.expose.9001: 'portal-k8ify-admin.apps.cloudscale-lpg-2.appuio.cloud'
       k8ify.share-storage: true
+      k8ify.liveness.path: /health/alive
+      k8ify.readiness.path: /health/ready
+      k8ify.readiness.scheme: HTTPS
+      k8ify.readiness.periodSeconds: 31
+      k8ify.readiness.timeoutSeconds: 59
+      k8ify.readiness.initialDelaySeconds: 5
+      k8ify.readiness.successThreshold: 2
+      k8ify.readiness.failureThreshold: 4
+      k8ify.startup.path: /health/started
     environment:
       - mongodb_hostname=mongo
       - mongodb_username=portal

--- a/tests/golden/demo/manifests/mongo-statefulset.yaml
+++ b/tests/golden/demo/manifests/mongo-statefulset.yaml
@@ -22,10 +22,24 @@ spec:
         - secretRef:
             name: mongo-env
         image: mongo:4.0
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 27017
+          timeoutSeconds: 60
         name: mongo
         ports:
         - containerPort: 27017
         resources: {}
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 27017
+          timeoutSeconds: 60
         volumeMounts:
         - mountPath: /data/db
           name: mongodb-data

--- a/tests/golden/demo/manifests/portal-mpi-deployment.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-deployment.yaml
@@ -26,11 +26,39 @@ spec:
         - secretRef:
             name: portal-mpi-env
         image: image-registry.openshift-image-registry.svc:5000/portal/portal:latest
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health/alive
+            port: 8000
+            scheme: HTTP
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 60
         name: portal-mpi
         ports:
         - containerPort: 8000
         - containerPort: 9000
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /health/ready
+            port: 8000
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 31
+          successThreshold: 2
+          timeoutSeconds: 59
         resources: {}
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /health/started
+            port: 8000
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 60
         volumeMounts:
         - mountPath: /src
           name: portal-mpi-claim0


### PR DESCRIPTION
I've added some magic.

* livenessProbe is enabled by default (but can be disabled).
* startupProbe is also enabled by default and uses the same settings as the livenessProbe, except for periodSeconds and failureThreshold.
* readinessProbe is disabled by default

What do you think?