### PR TITLE
fix: Ingress service backend must include refSlug

### DIFF
--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -309,7 +309,7 @@ func composeServiceToIngress(refSlug string, composeService composeTypes.Service
 			}
 
 			ingressServiceBackend := networking.IngressServiceBackend{
-				Name: composeService.Name,
+				Name: composeService.Name + refSlug,
 				Port: serviceBackendPort,
 			}
 

--- a/tests/golden/demo/manifests/portal-mpi-8001-ingress.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-8001-ingress.yaml
@@ -16,7 +16,7 @@ spec:
       paths:
       - backend:
           service:
-            name: portal
+            name: portal-mpi
             port:
               number: 8001
         path: /

--- a/tests/golden/demo/manifests/portal-mpi-9001-ingress.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-9001-ingress.yaml
@@ -16,7 +16,7 @@ spec:
       paths:
       - backend:
           service:
-            name: portal
+            name: portal-mpi
             port:
               number: 9001
         path: /


### PR DESCRIPTION
The ingresses set up by k8ify were not correct when refSlug was set. This fixes it.