### PR TITLE
feat: Configurable "command" and "args" in Deployments and StatefulSets

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -165,6 +165,10 @@ spec:
               cpu: 100m
               # `services.$name.deploy.resources.reservations.memory`
               memory: 256Mi
+          # `services.$name.entrypoint`, overwrites 'ENTRYPOINT' in Dockerfile
+          command: ["echo"]
+          # `services.$name.command`, overwrites 'CMD' in Dockerfile
+          args: ["Hello World"]
       # Values from `services.$name.volumes`, translated as the volumeMounts above
       volumes:
         - name: myapp-claim0
@@ -257,6 +261,10 @@ spec:
               cpu: 100m
               # `services.$name.deploy.resources.reservations.memory`
               memory: 256Mi
+          # `services.$name.entrypoint`, overwrites 'ENTRYPOINT' in Dockerfile
+          command: ["echo"]
+          # `services.$name.command`, overwrites 'CMD' in Dockerfile
+          args: ["Hello World"]
       # See PersistentVolumeClaim below for how the values are generated.
       volumeTemplates:
         - name: "myapp-claim0"
@@ -402,7 +410,8 @@ services:
     volumes:
       - "./:/src"
       - "myapp_data:/data"
-    command: sbt run
+    entrypoint: ["echo"]
+    command: ["Hello World"]
     environment:
       - mongodb_hostname=mongo
       - mongodb_database=$MONGO_DB

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -135,6 +135,8 @@ func composeServiceToDeployment(
 		volumeMounts,
 		labels,
 		resources,
+		composeService.Entrypoint,
+		composeService.Command,
 	)
 
 	deployment.Spec = apps.DeploymentSpec{
@@ -203,6 +205,8 @@ func composeServiceToStatefulSet(
 		volumeMounts,
 		labels,
 		resources,
+		composeService.Entrypoint,
+		composeService.Command,
 	)
 
 	statefulset.Spec = apps.StatefulSetSpec{
@@ -239,6 +243,8 @@ func composeServiceToPodTemplate(
 	volumeMounts []core.VolumeMount,
 	labels map[string]string,
 	resources core.ResourceRequirements,
+	entrypoint []string,
+	command []string,
 ) core.PodTemplateSpec {
 
 	container := core.Container{
@@ -262,6 +268,8 @@ func composeServiceToPodTemplate(
 		ReadinessProbe: readinessProbe,
 		StartupProbe:   startupProbe,
 		Resources:      resources,
+		Command:        entrypoint, // ENTRYPOINT in Docker == 'entrypoint' in Compose == 'command' in K8s
+		Args:           command,    // CMD in Docker == 'command' in Compose == 'args' in K8s
 	}
 
 	podSpec := core.PodSpec{

--- a/tests/golden/demo/docker-compose.yml
+++ b/tests/golden/demo/docker-compose.yml
@@ -20,7 +20,11 @@ services:
       - "8001:8000"
     volumes:
       - ./:/src
-    command: sbt run
+    entrypoint: 
+      - echo
+    command:
+      - "Hello World"
+      - "and hi k8ify!"
     stdin_open: true
     tty: true
     user: ${UID:-0}:${GID:-0}

--- a/tests/golden/demo/manifests/portal-mpi-deployment.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-deployment.yaml
@@ -22,7 +22,12 @@ spec:
         k8ify.service: portal
     spec:
       containers:
-      - envFrom:
+      - args:
+        - Hello World
+        - and hi k8ify!
+        command:
+        - echo
+        envFrom:
         - secretRef:
             name: portal-mpi-env
         image: image-registry.openshift-image-registry.svc:5000/portal/portal:latest


### PR DESCRIPTION
Make "command" and "args" in Deployments and StatefulSets configurable.

Note that:
* 'ENTRYPOINT' in Dockerfile == 'service.$name.entrypoint' in Compose == 'command' in K8s
* 'CMD' in Dockerfile == 'service.$name.command' in Compose == 'args' in K8s

Apart from that, as far as I can tell, these are 1:1 mappings. The final start command for the container is just 'command' and 'args' concatenated.

There is some discussion about this here:
https://stackoverflow.com/questions/44316361/difference-between-docker-entrypoint-and-kubernetes-container-spec-command