### PR TITLE
fix: Set imagePullPolicy to 'Always'

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -169,6 +169,8 @@ spec:
           command: ["echo"]
           # `services.$name.command`, overwrites 'CMD' in Dockerfile
           args: ["Hello World"]
+          # hard-coded
+          imagePullPolicy: Always
       # Values from `services.$name.volumes`, translated as the volumeMounts above
       volumes:
         - name: myapp-claim0
@@ -265,6 +267,8 @@ spec:
           command: ["echo"]
           # `services.$name.command`, overwrites 'CMD' in Dockerfile
           args: ["Hello World"]
+          # hard-coded
+          imagePullPolicy: Always
       # See PersistentVolumeClaim below for how the values are generated.
       volumeTemplates:
         - name: "myapp-claim0"

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -263,13 +263,14 @@ func composeServiceToPodTemplate(
 				},
 			},
 		},
-		VolumeMounts:   volumeMounts,
-		LivenessProbe:  livenessProbe,
-		ReadinessProbe: readinessProbe,
-		StartupProbe:   startupProbe,
-		Resources:      resources,
-		Command:        entrypoint, // ENTRYPOINT in Docker == 'entrypoint' in Compose == 'command' in K8s
-		Args:           command,    // CMD in Docker == 'command' in Compose == 'args' in K8s
+		VolumeMounts:    volumeMounts,
+		LivenessProbe:   livenessProbe,
+		ReadinessProbe:  readinessProbe,
+		StartupProbe:    startupProbe,
+		Resources:       resources,
+		Command:         entrypoint, // ENTRYPOINT in Docker == 'entrypoint' in Compose == 'command' in K8s
+		Args:            command,    // CMD in Docker == 'command' in Compose == 'args' in K8s
+		ImagePullPolicy: core.PullAlways,
 	}
 
 	podSpec := core.PodSpec{

--- a/tests/golden/101/manifests/nginx-mpi-deployment.yaml
+++ b/tests/golden/101/manifests/nginx-mpi-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         - secretRef:
             name: nginx-mpi-env
         image: docker.io/library/nginx
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
           periodSeconds: 30

--- a/tests/golden/defaults/manifests/nginx-mpi-deployment.yaml
+++ b/tests/golden/defaults/manifests/nginx-mpi-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         - secretRef:
             name: nginx-mpi-env
         image: docker.io/library/nginx
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
           periodSeconds: 30

--- a/tests/golden/demo/manifests/mongo-statefulset.yaml
+++ b/tests/golden/demo/manifests/mongo-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
         - secretRef:
             name: mongo-env
         image: mongo:4.0
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
           periodSeconds: 30

--- a/tests/golden/demo/manifests/portal-mpi-deployment.yaml
+++ b/tests/golden/demo/manifests/portal-mpi-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         - secretRef:
             name: portal-mpi-env
         image: image-registry.openshift-image-registry.svc:5000/portal/portal:latest
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
If imagePullPolicy is not set it defaults to "IfNotPresent", which can cause unexpected behavior because K8s might not fetch modified images from the registry. This is a problem for branch deployments where the image tag (=branch name) does not change.

This change fixes that by setting the imagePullPolicy to 'Always'.

Note that this does not necessarily fix all potential related issues with branch deployments; in particular pods still need to be manually restarted. K8s won't do this by default because the Deployment/StatefulSet doesn't change in this case.