### PR TITLE
feat: Specify changed images to force restart

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -99,6 +99,12 @@ spec:
     # * `start-first` -> `Rolling`
     type: Recreate
   template:
+    metadata:
+      annotations:
+        # If this Deployment uses one of the images that have been flagged as
+        # modified via the --modified-image argument, this is set to the current
+        # timestamp to ensure restarts of all pods
+        k8ify.restart-trigger: "1675680748"
     spec:
       containers:
           # If singleton or no ref given: `$name`, otherwise: `$name-$refSlug`
@@ -197,6 +203,12 @@ spec:
   # `services.$name.deploy.replicas`, defaults to `nil`
   replicas: 2
   template:
+    metadata:
+      annotations:
+        # If this StatefulSet uses one of the images that have been flagged as
+        # modified via the --modified-image argument, this is set to the current
+        # timestamp to ensure restarts of all pods
+        k8ify.restart-trigger: "1675680748"
     spec:
       containers:
           # If singleton or no ref given: `$name`, otherwise: `$name-$refSlug`

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/internal/cmdflags.go
+++ b/internal/cmdflags.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"fmt"
+)
+
+type ModifiedImagesFlag struct {
+	Values []string
+}
+
+func (this *ModifiedImagesFlag) Set(value string) error {
+	this.Values = append(this.Values, value)
+	return nil
+}
+
+func (this *ModifiedImagesFlag) String() string {
+	return fmt.Sprintf("%v", this.Values)
+}
+
+func (this *ModifiedImagesFlag) Type() string {
+	return "myapp:latest"
+}

--- a/main.go
+++ b/main.go
@@ -1,14 +1,16 @@
 package main
 
 import (
-	"log"
-	"os"
-
+	"fmt"
 	composeLoader "github.com/compose-spec/compose-go/loader"
 	composeTypes "github.com/compose-spec/compose-go/types"
+	"github.com/spf13/pflag"
 	"github.com/vshn/k8ify/internal"
 	"github.com/vshn/k8ify/pkg/converter"
 	"github.com/vshn/k8ify/pkg/util"
+	"log"
+	"os"
+	"time"
 )
 
 var (
@@ -18,20 +20,29 @@ var (
 		Ref:          "",
 		IngressPatch: converter.IngressPatch{},
 	}
+	modifiedImages internal.ModifiedImagesFlag
 )
 
 func main() {
+	pflag.Var(&modifiedImages, "modified-image", "Image that has been modified during the build. Can be repeated.")
 	code := Main(os.Args)
 	os.Exit(code)
 }
 
 func Main(args []string) int {
-	config := internal.ConfigMerge(defaultConfig, internal.ReadConfig(".k8ify.defaults.yaml"), internal.ReadConfig(".k8ify.local.yaml"))
-	if len(args) > 1 {
-		config.Env = args[1]
+	err := pflag.CommandLine.Parse(args[1:])
+	if err != nil {
+		log.Println(err)
+		return 1
 	}
-	if len(args) > 2 {
-		config.Ref = args[2]
+	plainArgs := pflag.Args()
+
+	config := internal.ConfigMerge(defaultConfig, internal.ReadConfig(".k8ify.defaults.yaml"), internal.ReadConfig(".k8ify.local.yaml"))
+	if len(plainArgs) > 0 {
+		config.Env = plainArgs[0]
+	}
+	if len(plainArgs) > 1 {
+		config.Ref = plainArgs[1]
 	}
 
 	if config.ConfigFiles == nil || len(config.ConfigFiles) == 0 {
@@ -64,6 +75,10 @@ func Main(args []string) int {
 	}
 
 	converter.PatchIngresses(objects.Ingresses, config.IngressPatch)
+	forceRestartAnnotation := make(map[string]string)
+	forceRestartAnnotation["k8ify.restart-trigger"] = fmt.Sprintf("%d", time.Now().Unix())
+	converter.PatchDeployments(objects.Deployments, modifiedImages.Values, forceRestartAnnotation)
+	converter.PatchStatefulSets(objects.StatefulSets, modifiedImages.Values, forceRestartAnnotation)
 
 	err = internal.WriteManifests(config.OutputDir, objects)
 	if err != nil {


### PR DESCRIPTION
Add dummy annotation to force K8s to restart Pods. This is useful for images that change without getting new tags, as it is common for test/review branch deployments. 

This problem does not exist for images that get new tags, e.g. for prod deployments. In these cases this change will also add the dummy annotation, but it does not introduce any new restarts because it affects the same K8s objects that are changed anyway because of the new image tag.

The intended usage pattern in a CI/CD pipeline is:
```
# build and tag image
docker build -t "${REGISTRY}/${NAMESPACE}/${CI_PROJECT_NAME}:${CI_COMMIT_REF_SLUG}"
[...]
# generate manifests
k8ify "${K8IFY_ENVIRONMENT}" "${K8IFY_DEPLOYMENT}" --modified-image "${NAMESPACE}/${CI_PROJECT_NAME}:${CI_COMMIT_REF_SLUG}"
```
As this parameter can be specified multiple times it can also cover use cases involving multiple images.

Since this parameter does not produce reproducible results (it adds the current unix timestamp into an annotation) I have not added Golden tests for it.

@mhutter  what do you think?