### PR TITLE
ci: Add Docker Build job

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,0 +1,31 @@
+name: 'Docker Build'
+
+on:
+  workflow_run:
+    workflows: ["Go"]
+    types:
+      - completed
+    tags:
+      - '**'
+
+env:
+  latest_tag: "${{ github.ref_type == 'tag' && ',docker.io/vshn/k8ify:latest' || '' }}"
+
+jobs:
+  dockerbuild:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} # GitHub will trigger this job no matter if 'Go' succeeded or failed, thus we need to check here
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker build
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: "docker.io/vshn/k8ify:${{ github.ref_name }}${{ env.latest_tag }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build
+FROM golang:latest AS build
+
+ENV HOME=/k8ify
+
+WORKDIR ${HOME}
+
+COPY . ${HOME}
+
+RUN go build -v .
+
+# Runtime
+FROM docker.io/appuio/oc:v4.11
+
+COPY --from=build k8ify /bin/


### PR DESCRIPTION
Add a CI job that builds a docker image and pushes it to dockerhub.

The base image is [appuio/oc](https://hub.docker.com/r/appuio/oc/), in order to have the necessary tooling to run CI jobs.


@mhutter  After a lot of trial and error :see_no_evil: I think it now does what I want.
