### PR TITLE
fix: Reduce collision probability of ref generator

### DIFF
--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -503,7 +503,7 @@ func toRefSlug(ref string, composeService composeTypes.ServiceConfig) string {
 }
 
 func ComposeServiceToK8s(ref string, composeService composeTypes.ServiceConfig) Objects {
-	refSlug := toRefSlug(util.SanitizeWithMinLength(ref, 3), composeService)
+	refSlug := toRefSlug(util.SanitizeWithMinLength(ref, 4), composeService)
 	labels := make(map[string]string)
 	labels["k8ify.service"] = composeService.Name
 	if refSlug != "" {

--- a/pkg/util/stringutils.go
+++ b/pkg/util/stringutils.go
@@ -2,8 +2,15 @@ package util
 
 import (
 	"crypto/sha512"
+	"math/big"
 	"regexp"
 	"strings"
+)
+
+var (
+	zero  = new(big.Int).SetInt64(0)
+	num26 = new(big.Int).SetInt64(26)
+	num36 = new(big.Int).SetInt64(36)
 )
 
 // Sanitize ensures a string only contains alphanumeric characters, and starts
@@ -24,9 +31,9 @@ func Sanitize(str string) string {
 // If the resulting string is too short, a stable generated value of
 // `minLength` characters will be returned.
 func SanitizeWithMinLength(str string, minLength int) string {
-	if minLength > 128 {
-		// The hash fall-back never produces anything longer than 128 chars so minLength above 128 does not work
-		minLength = 128
+	if minLength > 100 {
+		// The hash fall-back never produces anything longer than 100 chars so minLength above 100 does not work
+		minLength = 100
 	}
 	sanitized := Sanitize(str)
 	if len(sanitized) >= minLength {
@@ -35,15 +42,53 @@ func SanitizeWithMinLength(str string, minLength int) string {
 	// The input string does not have enough useful characters, so instead we hash the string
 	sha := sha512.New()
 	sha.Write([]byte(str))
-	alpha := ByteArrayToAlpha(sha.Sum(nil))
+	alpha := ByteArrayToAlphaNum(sha.Sum(nil))
 	return alpha[0:minLength]
 }
 
-// This is like hex encoding but instead of 0-f we use a-p
-func ByteArrayToAlpha(bytes []byte) string {
-	str := ""
-	for i := 0; i < len(bytes); i++ {
-		str = str + string(bytes[i]/16+97) + string(bytes[i]%16+97)
+func ByteArrayToAlphaNum(bytes []byte) string {
+	if len(bytes) == 0 {
+		return ""
 	}
+
+	// We want to guarantee that the resulting string length is always the same for a given input length, no matter what
+	// the input value.
+	// Consider this: If the input is e.g. 8 bytes long but the decimal value is only e.g. 5, this is the difference
+	// between producing "f" and "faaaaaaaaaaaa". If you were to feed 8 times the byte value 255 into this function you
+	// would get a 13 character long output, that's why the single "f" is padded with 12 "a"s.
+	// For this purpose we find the maximum value that would be possible with the given input length and keep adding
+	// characters to the output until the maximum value drops to 0.
+	maxValueBytes := make([]byte, len(bytes))
+	for i := 0; i < len(maxValueBytes); i++ {
+		maxValueBytes[i] = 255
+	}
+	maxValue := new(big.Int).SetBytes(maxValueBytes)
+
+	value := new(big.Int)
+	value.SetBytes(bytes)
+
+	remainder := new(big.Int)
+	str := ""
+
+	// first iteration uses divisor 26 in order to produce a-z
+	remainder.Mod(value, num26)
+	str = str + string(byte(remainder.Uint64())+97)
+	value.Div(value, num26)
+	maxValue.Div(maxValue, num26)
+
+	// subsequent iterations use divisor 36 in order to produce a-z, 0-9
+	// As outlined above we abort when the *maximum possible input value* for the given input length reaches 0, not
+	// when the *actual* value reaches 0
+	for maxValue.Cmp(zero) > 0 {
+		remainder.Mod(value, num36)
+		if remainder.Cmp(num26) < 0 {
+			str = str + string(byte(remainder.Uint64())+97)
+		} else {
+			str = str + string(byte(remainder.Uint64())+22)
+		}
+		value.Div(value, num36)
+		maxValue.Div(maxValue, num36)
+	}
+
 	return str
 }

--- a/pkg/util/stringutils_test.go
+++ b/pkg/util/stringutils_test.go
@@ -21,9 +21,27 @@ func TestSanitize(t *testing.T) {
 
 func TestSanitiziWithMinLength(t *testing.T) {
 	assert.Equal(t, "foobar", util.SanitizeWithMinLength("foobar", 6))
-	assert.Equal(t, "phpllk", util.SanitizeWithMinLength("foo", 6))
+	assert.Equal(t, "fr54k9", util.SanitizeWithMinLength("foo", 6))
 }
 
 func TestByteArrayToAlpha(t *testing.T) {
-	assert.Equal(t, "aaabacad", util.ByteArrayToAlpha([]byte{0, 1, 2, 3}))
+	assert.Equal(t, "", util.ByteArrayToAlphaNum([]byte{}))
+	assert.Equal(t, "aa", util.ByteArrayToAlphaNum([]byte{0}))
+	assert.Equal(t, "ba", util.ByteArrayToAlphaNum([]byte{1}))
+	assert.Equal(t, "za", util.ByteArrayToAlphaNum([]byte{25}))
+	assert.Equal(t, "ab", util.ByteArrayToAlphaNum([]byte{26}))
+	assert.Equal(t, "zb", util.ByteArrayToAlphaNum([]byte{51}))
+	assert.Equal(t, "ac", util.ByteArrayToAlphaNum([]byte{52}))
+	assert.Equal(t, "bc", util.ByteArrayToAlphaNum([]byte{53}))
+	assert.Equal(t, "a0aa", util.ByteArrayToAlphaNum([]byte{2, 164}))
+	assert.Equal(t, "a9aa", util.ByteArrayToAlphaNum([]byte{3, 142}))
+	assert.Equal(t, "z9aa", util.ByteArrayToAlphaNum([]byte{3, 167}))
+	assert.Equal(t, "aaba", util.ByteArrayToAlphaNum([]byte{3, 168}))
+	assert.Equal(t, "faaaaaaaaaaaa", util.ByteArrayToAlphaNum([]byte{0, 0, 0, 0, 0, 0, 0, 5}))
+	assert.Equal(t, "aaabacad", util.ByteArrayToAlphaNum([]byte{39, 141, 108, 23, 160}))
+	maxHashValue := make([]byte, 64)
+	for i := 0; i < 64; i++ {
+		maxHashValue[i] = 255
+	}
+	assert.Equal(t, "vjyw9istw1eo0gijxmt8ogd0ittw5jzslzuqb70zyf4aes4kc2j913cu0sjpfva7hytf3gk486srdn7wpyrtoesukpqzoilrknub", util.ByteArrayToAlphaNum(maxHashValue))
 }

--- a/tests/golden/101/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/101/manifests/nginx-oasp-deployment.yaml
@@ -3,27 +3,28 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: nginx
-  name: nginx-mpi
+  name: nginx-oasp
 spec:
+  replicas: 3
   selector:
     matchLabels:
-      k8ify.ref-slug: mpi
+      k8ify.ref-slug: oasp
       k8ify.service: nginx
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null
       labels:
-        k8ify.ref-slug: mpi
+        k8ify.ref-slug: oasp
         k8ify.service: nginx
     spec:
       containers:
       - envFrom:
         - secretRef:
-            name: nginx-mpi-env
+            name: nginx-oasp-env
         image: docker.io/library/nginx
         imagePullPolicy: Always
         livenessProbe:
@@ -33,7 +34,7 @@ spec:
           tcpSocket:
             port: 80
           timeoutSeconds: 60
-        name: nginx-mpi
+        name: nginx-oasp
         ports:
         - containerPort: 80
         resources: {}

--- a/tests/golden/101/manifests/nginx-oasp-env-secret.yaml
+++ b/tests/golden/101/manifests/nginx-oasp-env-secret.yaml
@@ -4,6 +4,6 @@ kind: Secret
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: nginx
-  name: nginx-mpi-env
+  name: nginx-oasp-env

--- a/tests/golden/101/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/101/manifests/nginx-oasp-service.yaml
@@ -4,16 +4,16 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: nginx
-  name: nginx-mpi
+  name: nginx-oasp
 spec:
   ports:
   - name: "8080"
     port: 8080
     targetPort: 80
   selector:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: nginx
 status:
   loadBalancer: {}

--- a/tests/golden/defaults/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/defaults/manifests/nginx-oasp-deployment.yaml
@@ -3,28 +3,27 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: nginx
-  name: nginx-mpi
+  name: nginx-oasp
 spec:
-  replicas: 3
   selector:
     matchLabels:
-      k8ify.ref-slug: mpi
+      k8ify.ref-slug: oasp
       k8ify.service: nginx
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       creationTimestamp: null
       labels:
-        k8ify.ref-slug: mpi
+        k8ify.ref-slug: oasp
         k8ify.service: nginx
     spec:
       containers:
       - envFrom:
         - secretRef:
-            name: nginx-mpi-env
+            name: nginx-oasp-env
         image: docker.io/library/nginx
         imagePullPolicy: Always
         livenessProbe:
@@ -34,7 +33,7 @@ spec:
           tcpSocket:
             port: 80
           timeoutSeconds: 60
-        name: nginx-mpi
+        name: nginx-oasp
         ports:
         - containerPort: 80
         resources: {}

--- a/tests/golden/defaults/manifests/nginx-oasp-env-secret.yaml
+++ b/tests/golden/defaults/manifests/nginx-oasp-env-secret.yaml
@@ -4,6 +4,6 @@ kind: Secret
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: nginx
-  name: nginx-mpi-env
+  name: nginx-oasp-env

--- a/tests/golden/defaults/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/defaults/manifests/nginx-oasp-service.yaml
@@ -4,16 +4,16 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: nginx
-  name: nginx-mpi
+  name: nginx-oasp
 spec:
   ports:
   - name: "8080"
     port: 8080
     targetPort: 80
   selector:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: nginx
 status:
   loadBalancer: {}

--- a/tests/golden/demo/manifests/portal-oasp-8001-ingress.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-8001-ingress.yaml
@@ -6,9 +6,9 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-production
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: portal
-  name: portal-mpi-8001
+  name: portal-oasp-8001
 spec:
   rules:
   - host: portal-k8ify.apps.cloudscale-lpg-2.appuio.cloud
@@ -16,7 +16,7 @@ spec:
       paths:
       - backend:
           service:
-            name: portal-mpi
+            name: portal-oasp
             port:
               number: 8001
         path: /
@@ -24,6 +24,6 @@ spec:
   tls:
   - hosts:
     - portal-k8ify.apps.cloudscale-lpg-2.appuio.cloud
-    secretName: portal-mpi-8001-tls
+    secretName: portal-oasp-8001-tls
 status:
   loadBalancer: {}

--- a/tests/golden/demo/manifests/portal-oasp-9001-ingress.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-9001-ingress.yaml
@@ -6,9 +6,9 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-production
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: portal
-  name: portal-mpi-9001
+  name: portal-oasp-9001
 spec:
   rules:
   - host: portal-k8ify-admin.apps.cloudscale-lpg-2.appuio.cloud
@@ -16,7 +16,7 @@ spec:
       paths:
       - backend:
           service:
-            name: portal-mpi
+            name: portal-oasp
             port:
               number: 9001
         path: /
@@ -24,6 +24,6 @@ spec:
   tls:
   - hosts:
     - portal-k8ify-admin.apps.cloudscale-lpg-2.appuio.cloud
-    secretName: portal-mpi-9001-tls
+    secretName: portal-oasp-9001-tls
 status:
   loadBalancer: {}

--- a/tests/golden/demo/manifests/portal-oasp-claim0-persistentvolumeclaim.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-claim0-persistentvolumeclaim.yaml
@@ -4,9 +4,9 @@ kind: PersistentVolumeClaim
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: portal
-  name: portal-mpi-claim0
+  name: portal-oasp-claim0
 spec:
   accessModes:
   - ReadWriteMany

--- a/tests/golden/demo/manifests/portal-oasp-deployment.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-deployment.yaml
@@ -3,14 +3,14 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: portal
-  name: portal-mpi
+  name: portal-oasp
 spec:
   replicas: 2
   selector:
     matchLabels:
-      k8ify.ref-slug: mpi
+      k8ify.ref-slug: oasp
       k8ify.service: portal
   strategy:
     type: Recreate
@@ -18,7 +18,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        k8ify.ref-slug: mpi
+        k8ify.ref-slug: oasp
         k8ify.service: portal
     spec:
       containers:
@@ -29,7 +29,7 @@ spec:
         - echo
         envFrom:
         - secretRef:
-            name: portal-mpi-env
+            name: portal-oasp-env
         image: image-registry.openshift-image-registry.svc:5000/portal/portal:latest
         imagePullPolicy: Always
         livenessProbe:
@@ -41,7 +41,7 @@ spec:
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 60
-        name: portal-mpi
+        name: portal-oasp
         ports:
         - containerPort: 8000
         - containerPort: 9000
@@ -73,10 +73,10 @@ spec:
           timeoutSeconds: 60
         volumeMounts:
         - mountPath: /src
-          name: portal-mpi-claim0
+          name: portal-oasp-claim0
       restartPolicy: Always
       volumes:
-      - name: portal-mpi-claim0
+      - name: portal-oasp-claim0
         persistentVolumeClaim:
-          claimName: portal-mpi-claim0
+          claimName: portal-oasp-claim0
 status: {}

--- a/tests/golden/demo/manifests/portal-oasp-env-secret.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-env-secret.yaml
@@ -4,9 +4,9 @@ kind: Secret
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: portal
-  name: portal-mpi-env
+  name: portal-oasp-env
 stringData:
   mongodb_database: portal
   mongodb_disable_tls: "true"

--- a/tests/golden/demo/manifests/portal-oasp-service.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-service.yaml
@@ -4,9 +4,9 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: portal
-  name: portal-mpi
+  name: portal-oasp
 spec:
   ports:
   - name: "8001"
@@ -16,7 +16,7 @@ spec:
     port: 9001
     targetPort: 9000
   selector:
-    k8ify.ref-slug: mpi
+    k8ify.ref-slug: oasp
     k8ify.service: portal
 status:
   loadBalancer: {}


### PR DESCRIPTION
Increase the per-character entropy of the ByteArrayToAlpha function by replacing it with a ByteArrayToAlphaNum function. The purpose of this change is to reduce the risk of colliding resource names due to colliding ref names. This change takes the risk of two refs colliding down from 1/4096 to 1/1213056. Note that the risk of collisions rises very quickly with more than two generated refs (birthday paradox) so this change is even more important in those cases.

ByteArrayToAlphaNum will produce [a-z] for the first character and [a-z0-9] for subsequent characters. It uses all the bits from the input exactly once, hence it does a 1:1 mapping from a byte array to a string. The output length only depends on the input length, not the input value; if the input value is low, it may get padded with 'a's to produce the desired output length. This is similar to what hex encoding would produce.

ByteArrayToAlphaNum will be rather slow because it relies on big.Int but that's OK for our use case.

Apart from improving the entropy in the generated refs we also increase the minimum ref length from 3 to 4.

Note that this changes the names of all resources that use a generated ref, thus it is a breaking change. Since at the moment we do not have any production systems which use these generated refs there should be no harm in that. 