### PR TITLE
fix: Do not re-use yaml printer to avoid printing separators

### DIFF
--- a/internal/output.go
+++ b/internal/output.go
@@ -32,11 +32,12 @@ func prepareOutputDir(outputDir string) error {
 	return nil
 }
 
-func writeManifest(yp *printers.YAMLPrinter, obj runtime.Object, destination string) error {
+func writeManifest(obj runtime.Object, destination string) error {
 	f, err := os.Create(destination)
 	if err != nil {
 		return err
 	}
+	yp := printers.YAMLPrinter{}
 	err = yp.PrintObj(obj, f)
 	if err != nil {
 		return err
@@ -55,10 +56,8 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 		os.Exit(1)
 	}
 
-	yp := printers.YAMLPrinter{}
-
 	for _, deployment := range objects.Deployments {
-		err := writeManifest(&yp, &deployment, outputDir+"/"+deployment.Name+"-deployment.yaml")
+		err := writeManifest(&deployment, outputDir+"/"+deployment.Name+"-deployment.yaml")
 		if err != nil {
 			return err
 		}
@@ -66,7 +65,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 	log.Printf("wrote %d deployments\n", len(objects.Deployments))
 
 	for _, statefulset := range objects.StatefulSets {
-		err := writeManifest(&yp, &statefulset, outputDir+"/"+statefulset.Name+"-statefulset.yaml")
+		err := writeManifest(&statefulset, outputDir+"/"+statefulset.Name+"-statefulset.yaml")
 		if err != nil {
 			return err
 		}
@@ -74,7 +73,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 	log.Printf("wrote %d statefulsets\n", len(objects.StatefulSets))
 
 	for _, service := range objects.Services {
-		err := writeManifest(&yp, &service, outputDir+"/"+service.Name+"-service.yaml")
+		err := writeManifest(&service, outputDir+"/"+service.Name+"-service.yaml")
 		if err != nil {
 			return err
 		}
@@ -82,7 +81,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 	log.Printf("wrote %d services\n", len(objects.Services))
 
 	for _, persistentVolumeClaim := range objects.PersistentVolumeClaims {
-		err := writeManifest(&yp, &persistentVolumeClaim, outputDir+"/"+persistentVolumeClaim.Name+"-persistentvolumeclaim.yaml")
+		err := writeManifest(&persistentVolumeClaim, outputDir+"/"+persistentVolumeClaim.Name+"-persistentvolumeclaim.yaml")
 		if err != nil {
 			return err
 		}
@@ -90,7 +89,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 	log.Printf("wrote %d persistentVolumeClaims\n", len(objects.PersistentVolumeClaims))
 
 	for _, secret := range objects.Secrets {
-		err := writeManifest(&yp, &secret, outputDir+"/"+secret.Name+"-secret.yaml")
+		err := writeManifest(&secret, outputDir+"/"+secret.Name+"-secret.yaml")
 		if err != nil {
 			return err
 		}
@@ -98,7 +97,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 	log.Printf("wrote %d secrets\n", len(objects.Secrets))
 
 	for _, ingress := range objects.Ingresses {
-		err := writeManifest(&yp, &ingress, outputDir+"/"+ingress.Name+"-ingress.yaml")
+		err := writeManifest(&ingress, outputDir+"/"+ingress.Name+"-ingress.yaml")
 		if err != nil {
 			return err
 		}

--- a/tests/golden/101/manifests/nginx-oasp-env-secret.yaml
+++ b/tests/golden/101/manifests/nginx-oasp-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/101/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/101/manifests/nginx-oasp-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/defaults/manifests/nginx-oasp-env-secret.yaml
+++ b/tests/golden/defaults/manifests/nginx-oasp-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/defaults/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/defaults/manifests/nginx-oasp-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/demo/manifests/mongo-env-secret.yaml
+++ b/tests/golden/demo/manifests/mongo-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/demo/manifests/mongo-service.yaml
+++ b/tests/golden/demo/manifests/mongo-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/demo/manifests/mongo-statefulset.yaml
+++ b/tests/golden/demo/manifests/mongo-statefulset.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/golden/demo/manifests/portal-oasp-8001-ingress.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-8001-ingress.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/tests/golden/demo/manifests/portal-oasp-9001-ingress.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-9001-ingress.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/tests/golden/demo/manifests/portal-oasp-env-secret.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/demo/manifests/portal-oasp-service.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/storage/manifests/default-oasp-env-secret.yaml
+++ b/tests/golden/storage/manifests/default-oasp-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/storage/manifests/default-oasp-service.yaml
+++ b/tests/golden/storage/manifests/default-oasp-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/storage/manifests/default-oasp-statefulset.yaml
+++ b/tests/golden/storage/manifests/default-oasp-statefulset.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/golden/storage/manifests/default-shared-data-oas-persistentvolumeclaim.yaml
+++ b/tests/golden/storage/manifests/default-shared-data-oas-persistentvolumeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/tests/golden/storage/manifests/default-shared-oasp-env-secret.yaml
+++ b/tests/golden/storage/manifests/default-shared-oasp-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/storage/manifests/default-shared-oasp-service.yaml
+++ b/tests/golden/storage/manifests/default-shared-oasp-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/storage/manifests/share-0-oasp-deployment.yaml
+++ b/tests/golden/storage/manifests/share-0-oasp-deployment.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/tests/golden/storage/manifests/share-0-oasp-env-secret.yaml
+++ b/tests/golden/storage/manifests/share-0-oasp-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/storage/manifests/share-0-oasp-service.yaml
+++ b/tests/golden/storage/manifests/share-0-oasp-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/storage/manifests/share-1-oasp-deployment.yaml
+++ b/tests/golden/storage/manifests/share-1-oasp-deployment.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/tests/golden/storage/manifests/share-1-oasp-env-secret.yaml
+++ b/tests/golden/storage/manifests/share-1-oasp-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/storage/manifests/share-1-oasp-service.yaml
+++ b/tests/golden/storage/manifests/share-1-oasp-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/storage/manifests/shared-data-oas-persistentvolumeclaim.yaml
+++ b/tests/golden/storage/manifests/shared-data-oas-persistentvolumeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/tests/golden/storage/manifests/singleton-db-env-secret.yaml
+++ b/tests/golden/storage/manifests/singleton-db-env-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/golden/storage/manifests/singleton-db-service.yaml
+++ b/tests/golden/storage/manifests/singleton-db-service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/golden/storage/manifests/singleton-db-statefulset.yaml
+++ b/tests/golden/storage/manifests/singleton-db-statefulset.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
Do not reuse the yaml printer because doing so prints separators starting with the second file. This lead to race conditions in the test cases because the first file wasn't always the same.

Relevant code in the yaml printer: https://github.com/kubernetes/cli-runtime/blob/v0.26.1/pkg/printers/yaml.go#L49

Unfortunately that code is not smart enough to realize that it is being called with a different destination file every time, and thus the counter isn't correct for that file. This may be good enough for the k8s CLI use case but it is not good enough for our use case.

There is no way to disable that behavior, so we just create a new yaml printer instance for every document, which removes all the separators from the output files.