### PR TITLE
Use logrus for all logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/compose-spec/compose-go v1.9.0
 	github.com/docker/go-units v0.5.0
 	github.com/joho/godotenv v1.5.1
+	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
 	gopkg.in/yaml.v3 v3.0.1
@@ -32,7 +33,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/golden_test.go
+++ b/golden_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -28,6 +30,10 @@ type Instance struct {
 type Environment struct {
 	Refs []string          `yaml:"refs"`
 	Vars map[string]string `yaml:"vars"`
+}
+
+func init() {
+	logrus.SetOutput(io.Discard)
 }
 
 // GetRefs returns the list of refs defined in the test spec, or just an empty

--- a/internal/output.go
+++ b/internal/output.go
@@ -1,10 +1,10 @@
 package internal
 
 import (
-	"log"
 	"os"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vshn/k8ify/pkg/converter"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -52,7 +52,7 @@ func writeManifest(obj runtime.Object, destination string) error {
 func WriteManifests(outputDir string, objects converter.Objects) error {
 	err := prepareOutputDir(outputDir)
 	if err != nil {
-		log.Fatal(err)
+		logrus.Error(err)
 		os.Exit(1)
 	}
 
@@ -62,7 +62,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 			return err
 		}
 	}
-	log.Printf("wrote %d deployments\n", len(objects.Deployments))
+	logrus.Infof("wrote %d deployments\n", len(objects.Deployments))
 
 	for _, statefulset := range objects.StatefulSets {
 		err := writeManifest(&statefulset, outputDir+"/"+statefulset.Name+"-statefulset.yaml")
@@ -70,7 +70,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 			return err
 		}
 	}
-	log.Printf("wrote %d statefulsets\n", len(objects.StatefulSets))
+	logrus.Infof("wrote %d statefulsets\n", len(objects.StatefulSets))
 
 	for _, service := range objects.Services {
 		err := writeManifest(&service, outputDir+"/"+service.Name+"-service.yaml")
@@ -78,7 +78,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 			return err
 		}
 	}
-	log.Printf("wrote %d services\n", len(objects.Services))
+	logrus.Infof("wrote %d services\n", len(objects.Services))
 
 	for _, persistentVolumeClaim := range objects.PersistentVolumeClaims {
 		err := writeManifest(&persistentVolumeClaim, outputDir+"/"+persistentVolumeClaim.Name+"-persistentvolumeclaim.yaml")
@@ -86,7 +86,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 			return err
 		}
 	}
-	log.Printf("wrote %d persistentVolumeClaims\n", len(objects.PersistentVolumeClaims))
+	logrus.Infof("wrote %d persistentVolumeClaims\n", len(objects.PersistentVolumeClaims))
 
 	for _, secret := range objects.Secrets {
 		err := writeManifest(&secret, outputDir+"/"+secret.Name+"-secret.yaml")
@@ -94,7 +94,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 			return err
 		}
 	}
-	log.Printf("wrote %d secrets\n", len(objects.Secrets))
+	logrus.Infof("wrote %d secrets\n", len(objects.Secrets))
 
 	for _, ingress := range objects.Ingresses {
 		err := writeManifest(&ingress, outputDir+"/"+ingress.Name+"-ingress.yaml")
@@ -102,7 +102,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 			return err
 		}
 	}
-	log.Printf("wrote %d ingresses\n", len(objects.Ingresses))
+	logrus.Infof("wrote %d ingresses\n", len(objects.Ingresses))
 
 	return nil
 }

--- a/internal/prechecks.go
+++ b/internal/prechecks.go
@@ -1,38 +1,31 @@
 package internal
 
 import (
-	"fmt"
-	"log"
 	"os"
 
 	composeTypes "github.com/compose-spec/compose-go/types"
+	"github.com/sirupsen/logrus"
 	"github.com/vshn/k8ify/pkg/ir"
 )
 
-var reset = "\033[0m"
-var red = "\033[31m"
-var hLine = "--------------------------------------------------------------------------------"
-
-func logRed(line string) {
-	log.Print(red + line + reset)
-}
+const HLINE = "--------------------------------------------------------------------------------"
 
 func ComposeServicePrecheck(composeService composeTypes.ServiceConfig) {
 	if composeService.Deploy == nil || composeService.Deploy.Resources.Reservations == nil {
-		logRed(hLine)
-		logRed(fmt.Sprintf("  Service '%s' does not have any CPU/memory reservations defined.", composeService.Name))
-		logRed("  k8ify can generate K8s manifests regardless, but your service will be")
-		logRed("  unreliable or not work at all: It may not start at all, be slow to react")
-		logRed("  due to insufficient CPU time or get OOM killed due to insufficient memory.")
-		logRed("  Please specify CPU and memory reservations like this:")
-		logRed("    services:")
-		logRed(fmt.Sprintf("      %s:", composeService.Name))
-		logRed("        deploy:")
-		logRed("          resources:")
-		logRed("            reservations:    # Minimum guaranteed by K8s to be always available")
-		logRed("              cpus: \"0.2\"    # Number of CPU cores. Quotes are required!")
-		logRed("              memory: 256M")
-		logRed(hLine)
+		logrus.Error(HLINE)
+		logrus.Errorf("  Service '%s' does not have any CPU/memory reservations defined.", composeService.Name)
+		logrus.Error("  k8ify can generate K8s manifests regardless, but your service will be")
+		logrus.Error("  unreliable or not work at all: It may not start at all, be slow to react")
+		logrus.Error("  due to insufficient CPU time or get OOM killed due to insufficient memory.")
+		logrus.Error("  Please specify CPU and memory reservations like this:")
+		logrus.Error("    services:")
+		logrus.Errorf("      %s:", composeService.Name)
+		logrus.Error("        deploy:")
+		logrus.Error("          resources:")
+		logrus.Error("            reservations:    # Minimum guaranteed by K8s to be always available")
+		logrus.Error(`              cpus: "0.2"    # Number of CPU cores. Quotes are required!`)
+		logrus.Error("              memory: 256M")
+		logrus.Error(HLINE)
 	}
 }
 
@@ -46,13 +39,13 @@ func VolumesPrecheck(inputs *ir.Inputs) {
 
 			// CHECK: Volume does not exist
 			if !ok {
-				logRed(fmt.Sprintf("Service %q references volume %q, which is not defined!", service.Name, volumeName))
+				logrus.Errorf("Service %q references volume %q, which is not defined!", service.Name, volumeName)
 				os.Exit(1)
 			}
 
 			// CHECK: Service is singleton but volume is not
 			if service.IsSingleton() != volume.IsSingleton() {
-				logRed(fmt.Sprintf("Service %q, Volume %q: `k8ify.singleton` labels must be identical", service.Name, volumeName))
+				logrus.Errorf("Service %q, Volume %q: `k8ify.singleton` labels must be identical", service.Name, volumeName)
 				os.Exit(1)
 			}
 
@@ -63,19 +56,18 @@ func VolumesPrecheck(inputs *ir.Inputs) {
 	for name, volume := range inputs.Volumes {
 		// CHECK: No size defined
 		if volume.SizeIsMissing() {
-			logRed(fmt.Sprintf("WARNING: Volume %q has no size specified!", name))
+			logrus.Errorf("WARNING: Volume %q has no size specified!", name)
 		}
 
 		// CHECK: Volume defined but not used in any services
 		if len(references[name]) < 1 {
-			logRed(fmt.Sprintf("WARNING: Volume %q is defined but not referenced by any workloads", name))
+			logrus.Errorf("WARNING: Volume %q is defined but not referenced by any workloads", name)
 			continue
 		}
 
 		// CHECK: Same non-shared volume on multiple services
 		if !volume.IsShared() && len(references[name]) > 1 {
-			logRed(fmt.Sprintf("Volume %q is not marked as shared (via the `k8ify.shared` label on the volume),", name))
-			logRed("but is used by multiple services.")
+			logrus.Errorf("Volume %q is not marked as shared (via the `k8ify.shared` label on the volume), but is used by multiple services.", name)
 			os.Exit(1)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/joho/godotenv"
-	"log"
 	"os"
 	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
 
 	composeLoader "github.com/compose-spec/compose-go/loader"
 	composeTypes "github.com/compose-spec/compose-go/types"
@@ -37,7 +38,7 @@ func main() {
 func Main(args []string) int {
 	err := pflag.CommandLine.Parse(args[1:])
 	if err != nil {
-		log.Println(err)
+		logrus.Error(err)
 		return 1
 	}
 	plainArgs := pflag.Args()
@@ -59,7 +60,7 @@ func Main(args []string) int {
 	for _, shellEnvFile := range shellEnvFiles.Values {
 		err := godotenv.Load(shellEnvFile)
 		if err != nil {
-			log.Println(err)
+			logrus.Error(err)
 			return 1
 		}
 	}
@@ -78,7 +79,7 @@ func Main(args []string) int {
 	}
 	project, err := composeLoader.Load(configDetails)
 	if err != nil {
-		log.Println(err)
+		logrus.Error(err)
 		return 1
 	}
 
@@ -105,7 +106,7 @@ func Main(args []string) int {
 
 	err = internal.WriteManifests(config.OutputDir, objects)
 	if err != nil {
-		log.Println(err)
+		logrus.Error(err)
 		return 1
 	}
 

--- a/pkg/util/configutils.go
+++ b/pkg/util/configutils.go
@@ -1,12 +1,13 @@
 package util
 
 import (
-	"log"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/docker/go-units"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -104,7 +105,8 @@ func StorageSize(labels map[string]string, fallback string) resource.Quantity {
 
 	size, err := units.RAMInBytes(quantity)
 	if err != nil {
-		log.Fatalf("ERROR: Invalid storage size: %q\n", quantity)
+		logrus.Errorf("ERROR: Invalid storage size: %q\n", quantity)
+		os.Exit(1)
 	}
 
 	return *resource.NewQuantity(size, resource.BinarySI)


### PR DESCRIPTION
The compose project already uses logrus for logging, and it does what we need, so it seemed reasonable to use the same here.

Reusing the same library also allows us to reconfigure all logging (eg. for tests) in one go.

I replaced all output by logrus calls. I refrained from using `logrus.Fatal` (which prints the error message and then terminates the process with exit code 1), and left in all the explicit `os.Exit(1)` calls instead.

Preview of how it looks:

![ss](https://user-images.githubusercontent.com/346819/222153518-f8c261f1-039a-4329-84d4-e712b7ab9f0e.png)

Ref: APPX-30