### PR TITLE
feat: Make pod spec.serviceAccountName configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Service Labels
 | `k8ify.expose.$port: $host`  | The port `$port` is exposed to the internet via a HTTPS ingress with the host name set to `$host`  |
 | `k8ify.converter: $script`  | Call `$script` to convert this service into a K8s object, expecting YAML on `$script`'s stdout. Used for plugging additional functionality into k8ify. The first argument sent to `$script` is the name of the resource, after that all the parameters follow (next row) |
 | `k8ify.converter.$key: $value`  | Call `$script` with parameter `--$key $value` |
+| `k8ify.serviceAccountName: $name`  | Set this service's pod(s) spec.serviceAccountName to `$name`, which tells the pod(s) to use ServiceAccount `$name` for accessing the K8s API. This does not set up the ServiceAcccount itself. |
 
 Volume Labels
 

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -183,6 +183,8 @@ spec:
           args: ["Hello World"]
           # hard-coded
           imagePullPolicy: Always
+          # `services.$name.labels["k8ify.serviceAccountName"], not set by default
+          serviceAccountName: "myappk8saccess"
       # Values from `services.$name.volumes`, translated as the volumeMounts above
       volumes:
         - name: myapp-data
@@ -281,6 +283,8 @@ spec:
           args: ["Hello World"]
           # hard-coded
           imagePullPolicy: Always
+          # `services.$name.labels["k8ify.serviceAccountName"], not set by default
+          serviceAccountName: "myappk8saccess"
       # See PersistentVolumeClaim below for how the values are generated.
       volumeTemplates:
         - metadata:

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -124,6 +124,7 @@ func composeServiceToDeployment(
 		resources,
 		composeService.Entrypoint,
 		composeService.Command,
+		util.ServiceAccountName(composeService.Labels),
 	)
 
 	deployment.Spec = apps.DeploymentSpec{
@@ -194,6 +195,7 @@ func composeServiceToStatefulSet(
 		resources,
 		composeService.Entrypoint,
 		composeService.Command,
+		util.ServiceAccountName(composeService.Labels),
 	)
 
 	statefulset.Spec = apps.StatefulSetSpec{
@@ -232,6 +234,7 @@ func composeServiceToPodTemplate(
 	resources core.ResourceRequirements,
 	entrypoint []string,
 	command []string,
+	serviceAccountName string,
 ) core.PodTemplateSpec {
 
 	container := core.Container{
@@ -261,9 +264,10 @@ func composeServiceToPodTemplate(
 	}
 
 	podSpec := core.PodSpec{
-		Containers:    []core.Container{container},
-		RestartPolicy: core.RestartPolicyAlways,
-		Volumes:       volumes,
+		Containers:         []core.Container{container},
+		RestartPolicy:      core.RestartPolicyAlways,
+		Volumes:            volumes,
+		ServiceAccountName: serviceAccountName,
 	}
 
 	return core.PodTemplateSpec{

--- a/pkg/util/configutils.go
+++ b/pkg/util/configutils.go
@@ -115,3 +115,11 @@ func StorageSize(labels map[string]string, fallback string) resource.Quantity {
 
 	return *resource.NewQuantity(size, resource.BinarySI)
 }
+
+func ServiceAccountName(labels map[string]string) string {
+	serviceAccountName := GetOptional(labels, "k8ify.serviceAccountName")
+	if serviceAccountName == nil {
+		return ""
+	}
+	return *serviceAccountName
+}

--- a/tests/golden/demo/docker-compose-prod.yml
+++ b/tests/golden/demo/docker-compose-prod.yml
@@ -21,6 +21,7 @@ services:
       k8ify.readiness.successThreshold: 2
       k8ify.readiness.failureThreshold: 4
       k8ify.startup.path: /health/started
+      k8ify.serviceAccountName: portalk8saccess
     environment:
       - mongodb_hostname=mongo
       - mongodb_username=portal

--- a/tests/golden/demo/manifests/portal-oasp-deployment.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-deployment.yaml
@@ -72,4 +72,5 @@ spec:
           successThreshold: 1
           timeoutSeconds: 60
       restartPolicy: Always
+      serviceAccountName: portalk8saccess
 status: {}


### PR DESCRIPTION
Add option to configure the pod's "spec.serviceAccountName" field.

This is useful for deploying applications that need to access the K8s API because with the help of this setting K8s mounts the ServiceAccount credentials into the pod.

This feature does not set up the ServiceAccount itself.