### PR TITLE
feat: Check domain name lengths and allow using cluster wildcard cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ This replaces the TCP based health check by a more specific HTTP(S) check.
 | `k8ify.readiness.*` | All the sub-values work the same as for `k8ify.liveness` incl. defaults. No values are copied over. However the readiness check is disabled by default. |
 | `k8ify.readiness.enabled: false` | Enable or disable the readiness check. Default is false. |
 
+#### Target Cluster Configuration
+
+There are some cases in which the output of k8ify needs to be different based on the target cluster's configuration. To make this work some properties of the target cluster can be configured via the `x-targetCfg` root key in the compose file.
+
+| Key  | Effect  |
+| ---- | ------- |
+| `appsDomain: $domain`  | A cluster may have a wildcard certificate for apps to use. If you configure this option and expose a service using `$domain`, the resulting Ingress uses this wildcard certificate (instead of e.g. Let's Encrypt). |
+| `maxExposeLength: $length`  | k8ify does a length check on the exposed domain names, because if they're too long the Ingress will not work. Default is 63.  |
 
 ## Conversion
 

--- a/main.go
+++ b/main.go
@@ -96,11 +96,12 @@ func Main(args []string) int {
 	inputs := ir.FromCompose(project)
 	internal.ComposeServicePrecheck(inputs)
 	internal.VolumesPrecheck(inputs)
+	internal.DomainLengthPrecheck(inputs)
 
 	objects := converter.Objects{}
 
 	for _, service := range inputs.Services {
-		objects = objects.Append(converter.ComposeServiceToK8s(config.Ref, service, inputs.Volumes))
+		objects = objects.Append(converter.ComposeServiceToK8s(config.Ref, service, inputs.Volumes, inputs.TargetCfg))
 	}
 
 	forceRestartAnnotation := make(map[string]string)

--- a/tests/golden/cluster-apps-domain.yml
+++ b/tests/golden/cluster-apps-domain.yml
@@ -1,0 +1,3 @@
+---
+environments:
+  prod: {}

--- a/tests/golden/cluster-apps-domain/compose.yml
+++ b/tests/golden/cluster-apps-domain/compose.yml
@@ -1,0 +1,10 @@
+services:
+  nginx:
+    labels:
+      k8ify.expose: foo.apps.cluster.net
+    image: docker.io/library/nginx
+    ports:
+      - '8080:80'
+
+x-targetCfg:
+  appsDomain: "*.apps.cluster.net"

--- a/tests/golden/cluster-apps-domain/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/cluster-apps-domain/manifests/nginx-oasp-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        k8ify.ref-slug: oasp
+        k8ify.service: nginx
+    spec:
+      containers:
+      - image: docker.io/library/nginx
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+        name: nginx-oasp
+        ports:
+        - containerPort: 80
+        resources: {}
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+      restartPolicy: Always
+status: {}

--- a/tests/golden/cluster-apps-domain/manifests/nginx-oasp-ingress.yaml
+++ b/tests/golden/cluster-apps-domain/manifests/nginx-oasp-ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  rules:
+  - host: foo.apps.cluster.net
+    http:
+      paths:
+      - backend:
+          service:
+            name: nginx-oasp
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+  tls:
+  - {}
+status:
+  loadBalancer: {}

--- a/tests/golden/cluster-apps-domain/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/cluster-apps-domain/manifests/nginx-oasp-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 80
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+status:
+  loadBalancer: {}


### PR DESCRIPTION
 Also see internal ticket APPX-27.

This PR adds a sanity check to verify that [exported domains aren't too long](https://community.letsencrypt.org/t/a-certificate-for-a-63-character-domain/78870), and adds support for using the target cluster's wildcard certificate, which works by creating an Ingress resource with the following spec:
```
spec:
  tls:
    - {}
```
(note that this is pretty much undocumented but seems to be officially supported. Of course this solves the problem of the long domain names because with the wildcard certificate we don't need to actually generate a certificate for these domains. And also obviously it will only work if the exposed domain is a direct subdomain covered by the wildcard cert)

However for this to work k8ify needs to know some more things about the target cluster. Hence we introduce a new mechanism for configuring properties of the target cluster. You can put the following into the compose yml:
```
x-targetCfg:
  appsDomain: "*.apps.cluster.example.com"
  maxExposeLength: 63
```

Reasons why I think this is a good idea:
* We can keep everything in the compose file(s). The use of "x-..." keys is actually supported by compose.
* If you have different target clusters in the same project you can easily overwrite these values via environment-specific compose files
* We already have a "provider" parameter which is currently used to use provider-specific features. This "provider" parameter can be replaced by this new mechanism in the future to keep everything unified (think "volumeEncryptionScheme: cloudscale" or something like this, internal ticket APPX-110)
* With this mechanism you can use environment variables in case you need to set these values more dynamically
* In the future we could support special environment variables as an alternative way of supplying target cluster configuration, e.g. instead of setting `x-targetCfg.appsDomain` the user could set the environment variable "X_TARGET_CFG_APPS_DOMAIN"). This isn't implemented yet.

Downsides:
* The AppFlow Web UI might know some of these parameters for the chosen target cluster, but there is currently no mechanism in place to automatically set this up. (once k8ify has support for "X_TARGET_CFG..." environment variables the AppFlow Web UI could generate those, in addition to the "KUBECONFIG_..." environment variables. Or alternatively the AppFlow Web UI could show the "x-targetCfg" yaml).