### PR TITLE
Fix: Ingress references wrong service under certain conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vshn/k8ify
 
-go 1.21
+go 1.22
 
 require (
 	github.com/compose-spec/compose-go v1.20.2

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -411,7 +411,7 @@ func composeServiceToIngress(workload *ir.Service, refSlug string, services []co
 	var service *core.Service
 	for _, s := range services {
 		if serviceSpecIsUnexposedDefault(s.Spec) {
-			service = &s
+			service = &s // This only works since Go 1.22
 		}
 	}
 	if service == nil {

--- a/tests/golden/expose-http-and-plain.yml
+++ b/tests/golden/expose-http-and-plain.yml
@@ -1,0 +1,3 @@
+---
+environments:
+  prod: {}

--- a/tests/golden/expose-http-and-plain/compose.yml
+++ b/tests/golden/expose-http-and-plain/compose.yml
@@ -1,0 +1,16 @@
+services:
+  nginx:
+    labels:
+      k8ify.expose.80: port80.example.com
+      k8ify.exposePlain.443: true
+      k8ify.exposePlain.443.externalTrafficPolicy: Cluster
+      k8ify.exposePlain.443.healthCheckNodePort: 55667
+      k8ify.exposePlain.22: true
+      k8ify.exposePlain.21: true
+    image: docker.io/library/nginx
+    ports:
+      - '88:8888'
+      - '80:8080'
+      - '443:8443'
+      - '22:2222'
+      - '21:2221'

--- a/tests/golden/expose-http-and-plain/manifests/nginx-oasp-22-21-service.yaml
+++ b/tests/golden/expose-http-and-plain/manifests/nginx-oasp-22-21-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp-22-21
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: "22"
+    port: 22
+    targetPort: 2222
+  - name: "21"
+    port: 21
+    targetPort: 2221
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/tests/golden/expose-http-and-plain/manifests/nginx-oasp-443-service.yaml
+++ b/tests/golden/expose-http-and-plain/manifests/nginx-oasp-443-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp-443
+spec:
+  externalTrafficPolicy: Cluster
+  healthCheckNodePort: 55667
+  ports:
+  - name: "443"
+    port: 443
+    targetPort: 8443
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/tests/golden/expose-http-and-plain/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/expose-http-and-plain/manifests/nginx-oasp-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        k8ify.ref-slug: oasp
+        k8ify.service: nginx
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8ify.service
+                operator: In
+                values:
+                - nginx
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: docker.io/library/nginx
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 8888
+          timeoutSeconds: 60
+        name: nginx-oasp
+        ports:
+        - containerPort: 8888
+        - containerPort: 8080
+        - containerPort: 8443
+        - containerPort: 2222
+        - containerPort: 2221
+        resources: {}
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 8888
+          timeoutSeconds: 60
+      restartPolicy: Always
+status: {}

--- a/tests/golden/expose-http-and-plain/manifests/nginx-oasp-ingress.yaml
+++ b/tests/golden/expose-http-and-plain/manifests/nginx-oasp-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  rules:
+  - host: port80.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: nginx-oasp
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - port80.example.com
+    secretName: nginx-oasp
+status:
+  loadBalancer: {}

--- a/tests/golden/expose-http-and-plain/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/expose-http-and-plain/manifests/nginx-oasp-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  ports:
+  - name: "88"
+    port: 88
+    targetPort: 8888
+  - name: "80"
+    port: 80
+    targetPort: 8080
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+status:
+  loadBalancer: {}


### PR DESCRIPTION
Fix an issue where an ingress would reference the wrong service object under certain conditions (more than one service object present).

This is actually fixed by upgrading to Go 1.22, since this problem was caused by weird handling of loop variables in older Go versions.