### PR TITLE
feat: Disable Service Links by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Service Labels
 | `k8ify.exposePlain.$port.type: ClusterIP\|LoadBalancer\|ExternalName\|NodePort`  | Set the k8s Service type (default `LoadBalancer`) |
 | `k8ify.exposePlain.$port.externalTrafficPolicy: Cluster\|Local`  | Set the k8s Service traffic policy (default `Local`). `Local` makes the client IP visible to the application but may provide worse load balancing than `Cluster`. |
 | `k8ify.exposePlain.$port.healthCheckNodePort: $port`  | Set the k8s Service health check port number. |
+| `k8ify.enableServiceLinks: $value` | Inject ENV variables for each K8s service in the namespace. |
 
 Volume Labels
 

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -116,6 +116,8 @@ spec:
         # `services.$name.labels["k8ify.annotations"]` merged with `services.$name.labels["k8ify.Pod.annotations"]` (latter take priority)
         foo: bar
     spec:
+      # `services.$name.labels."k8ify.enableServiceLinks`, defaults to `false`
+      enableServiceLinks: false
       # Anti-affinity is always configured to avoid running multiple replicas (instances) of the same deployment on the same node
       affinity:
         podAntiAffinity:
@@ -237,6 +239,8 @@ spec:
         # timestamp to ensure restarts of all pods
         k8ify.restart-trigger: "1675680748"
     spec:
+      # `services.$name.labels."k8ify.enableServiceLinks`, defaults to `false`
+      enableServiceLinks: false
       # Anti-affinity is always configured to avoid running multiple replicas (instances) of the same deployment on the same node
       affinity:
         podAntiAffinity:

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -255,7 +255,10 @@ func composeServiceToPodTemplate(
 		volumesArray = append(volumesArray, volumes[key])
 	}
 
+	enableServiceLinks := util.GetBoolean(workload.Labels(), "k8ify.enableServiceLinks")
+
 	podSpec := core.PodSpec{
+		EnableServiceLinks: &enableServiceLinks,
 		Containers:         containers,
 		RestartPolicy:      core.RestartPolicyAlways,
 		Volumes:            volumesArray,

--- a/tests/golden/101/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/101/manifests/nginx-oasp-deployment.yaml
@@ -52,5 +52,6 @@ spec:
           tcpSocket:
             port: 80
           timeoutSeconds: 60
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/cluster-apps-domain/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/cluster-apps-domain/manifests/nginx-oasp-deployment.yaml
@@ -51,5 +51,6 @@ spec:
           tcpSocket:
             port: 80
           timeoutSeconds: 60
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/defaults/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/defaults/manifests/nginx-oasp-deployment.yaml
@@ -51,5 +51,6 @@ spec:
           tcpSocket:
             port: 80
           timeoutSeconds: 60
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/demo/docker-compose.yml
+++ b/tests/golden/demo/docker-compose.yml
@@ -1,13 +1,15 @@
-version: '3.4'
+version: "3.4"
 services:
   mongo:
     image: mongo:4.0
     restart: always
     ports:
-      - '127.0.0.1:27017:27017'
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongodb_data:/data/db
   portal:
+    labels:
+      k8ify.enableServiceLinks: "true"
     image: vshn/portal:dev
     build:
       target: base
@@ -20,7 +22,7 @@ services:
       - "8001:8000"
     volumes:
       - ./:/src
-    entrypoint: 
+    entrypoint:
       - echo
     command:
       - "Hello World"

--- a/tests/golden/demo/manifests/mongo-statefulset.yaml
+++ b/tests/golden/demo/manifests/mongo-statefulset.yaml
@@ -63,6 +63,7 @@ spec:
         volumeMounts:
         - mountPath: /data/db
           name: mongodb-data
+      enableServiceLinks: false
       restartPolicy: Always
   updateStrategy: {}
   volumeClaimTemplates:

--- a/tests/golden/demo/manifests/portal-oasp-deployment.yaml
+++ b/tests/golden/demo/manifests/portal-oasp-deployment.yaml
@@ -81,6 +81,7 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 60
+      enableServiceLinks: true
       restartPolicy: Always
       serviceAccountName: portalk8saccess
 status: {}

--- a/tests/golden/empty-env-vars-list/manifests/pinger-oasp-deployment.yaml
+++ b/tests/golden/empty-env-vars-list/manifests/pinger-oasp-deployment.yaml
@@ -38,5 +38,6 @@ spec:
         imagePullPolicy: Always
         name: pinger-oasp
         resources: {}
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/empty-env-vars-map/manifests/pinger-oasp-deployment.yaml
+++ b/tests/golden/empty-env-vars-map/manifests/pinger-oasp-deployment.yaml
@@ -38,5 +38,6 @@ spec:
         imagePullPolicy: Always
         name: pinger-oasp
         resources: {}
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/env-vars/manifests/fooBar-oasp-deployment.yaml
+++ b/tests/golden/env-vars/manifests/fooBar-oasp-deployment.yaml
@@ -54,5 +54,6 @@ spec:
         imagePullPolicy: Always
         name: fooBar-oasp
         resources: {}
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/expose-http-and-plain/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/expose-http-and-plain/manifests/nginx-oasp-deployment.yaml
@@ -55,5 +55,6 @@ spec:
           tcpSocket:
             port: 8888
           timeoutSeconds: 60
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/expose-plain/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/expose-plain/manifests/nginx-oasp-deployment.yaml
@@ -55,5 +55,6 @@ spec:
           tcpSocket:
             port: 8888
           timeoutSeconds: 60
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/noports/manifests/pinger-oasp-deployment.yaml
+++ b/tests/golden/noports/manifests/pinger-oasp-deployment.yaml
@@ -35,5 +35,6 @@ spec:
         imagePullPolicy: Always
         name: pinger-oasp
         resources: {}
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/parts-ingress/manifests/nginx-frontend-oasp-deployment.yaml
+++ b/tests/golden/parts-ingress/manifests/nginx-frontend-oasp-deployment.yaml
@@ -71,5 +71,6 @@ spec:
           tcpSocket:
             port: 4480
           timeoutSeconds: 60
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/parts/manifests/mongo-statefulset.yaml
+++ b/tests/golden/parts/manifests/mongo-statefulset.yaml
@@ -84,6 +84,7 @@ spec:
         volumeMounts:
         - mountPath: /data/db
           name: mongodb-data
+      enableServiceLinks: false
       restartPolicy: Always
   updateStrategy: {}
   volumeClaimTemplates:

--- a/tests/golden/parts/manifests/nginx-frontend-oasp-deployment.yaml
+++ b/tests/golden/parts/manifests/nginx-frontend-oasp-deployment.yaml
@@ -98,6 +98,7 @@ spec:
           name: sessions
         - mountPath: /data/web
           name: webdata
+      enableServiceLinks: false
       restartPolicy: Always
       volumes:
       - name: sessions

--- a/tests/golden/poddisruptionbudget/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/poddisruptionbudget/manifests/nginx-oasp-deployment.yaml
@@ -52,5 +52,6 @@ spec:
           tcpSocket:
             port: 80
           timeoutSeconds: 60
+      enableServiceLinks: false
       restartPolicy: Always
 status: {}

--- a/tests/golden/storage-encrypted/manifests/default-oasp-statefulset.yaml
+++ b/tests/golden/storage-encrypted/manifests/default-oasp-statefulset.yaml
@@ -37,6 +37,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: default-data
+      enableServiceLinks: false
       restartPolicy: Always
   updateStrategy: {}
   volumeClaimTemplates:

--- a/tests/golden/storage-encrypted/manifests/default-shared-oasp-deployment.yaml
+++ b/tests/golden/storage-encrypted/manifests/default-shared-oasp-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: default-shared-data
+      enableServiceLinks: false
       restartPolicy: Always
       volumes:
       - name: default-shared-data

--- a/tests/golden/storage-encrypted/manifests/share-0-oasp-deployment.yaml
+++ b/tests/golden/storage-encrypted/manifests/share-0-oasp-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: shared-data
+      enableServiceLinks: false
       restartPolicy: Always
       volumes:
       - name: shared-data

--- a/tests/golden/storage-encrypted/manifests/share-1-oasp-deployment.yaml
+++ b/tests/golden/storage-encrypted/manifests/share-1-oasp-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: shared-data
+      enableServiceLinks: false
       restartPolicy: Always
       volumes:
       - name: shared-data

--- a/tests/golden/storage-encrypted/manifests/singleton-db-statefulset.yaml
+++ b/tests/golden/storage-encrypted/manifests/singleton-db-statefulset.yaml
@@ -34,6 +34,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: singleton-db-storage
+      enableServiceLinks: false
       restartPolicy: Always
   updateStrategy: {}
   volumeClaimTemplates:

--- a/tests/golden/storage/manifests/default-oasp-statefulset.yaml
+++ b/tests/golden/storage/manifests/default-oasp-statefulset.yaml
@@ -37,6 +37,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: default-data
+      enableServiceLinks: false
       restartPolicy: Always
   updateStrategy: {}
   volumeClaimTemplates:

--- a/tests/golden/storage/manifests/default-shared-oasp-deployment.yaml
+++ b/tests/golden/storage/manifests/default-shared-oasp-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: default-shared-data
+      enableServiceLinks: false
       restartPolicy: Always
       volumes:
       - name: default-shared-data

--- a/tests/golden/storage/manifests/share-0-oasp-deployment.yaml
+++ b/tests/golden/storage/manifests/share-0-oasp-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: shared-data
+      enableServiceLinks: false
       restartPolicy: Always
       volumes:
       - name: shared-data

--- a/tests/golden/storage/manifests/share-1-oasp-deployment.yaml
+++ b/tests/golden/storage/manifests/share-1-oasp-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: shared-data
+      enableServiceLinks: false
       restartPolicy: Always
       volumes:
       - name: shared-data

--- a/tests/golden/storage/manifests/singleton-db-statefulset.yaml
+++ b/tests/golden/storage/manifests/singleton-db-statefulset.yaml
@@ -34,6 +34,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: singleton-db-storage
+      enableServiceLinks: false
       restartPolicy: Always
   updateStrategy: {}
   volumeClaimTemplates:


### PR DESCRIPTION
In the default configuration, Kubernetes will inject a bunch of environment variables for each service in the Namespace. The idea is to aid with service discovery, but while they are rarely used in practice, the injected environment variables might interfere that try to determine their configuration from environment variables.

This commit disables this behaviour by default by setting `enableServiceLinks: false` in the pod specs, but allows users to reenable the links using a label.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

