### PR TITLE
Add support for mounting `emptyDir` volumes

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -41,6 +41,8 @@ This can be changed to `ReadWriteMany` by adding the label `k8ify.shared: true` 
 
 See [Storage](./storage.md) for a more detailed explanation.
 
+A special case are entries listed under a service's `tmpfs` attribute: Each path is translated to an `emptyDir` volume.
+
 #### Deployments vs. StatefulSets
 
 By default a Compose service will be translated to a `Deployment`. If a Compose service only uses shared (`ReadWriteMany`) volumes, it will still be translated to a `Deployment`.

--- a/tests/golden/storage/compose.yml
+++ b/tests/golden/storage/compose.yml
@@ -25,6 +25,10 @@ services:
     volumes:
       - singleton-db-storage:/data
 
+  tmpfs-service:
+    image: nginx
+    tmpfs:
+      - /tmp
 
 volumes:
   default-data: {}

--- a/tests/golden/storage/manifests/tmpfs-service-oasp-deployment.yaml
+++ b/tests/golden/storage/manifests/tmpfs-service-oasp-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: tmpfs-service
+  name: tmpfs-service-oasp
+spec:
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: tmpfs-service
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        k8ify.ref-slug: oasp
+        k8ify.service: tmpfs-service
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8ify.service
+                operator: In
+                values:
+                - tmpfs-service
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: nginx
+        imagePullPolicy: Always
+        name: tmpfs-service-oasp
+        resources: {}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmpfs-service-tmpfs-tmp
+      enableServiceLinks: false
+      restartPolicy: Always
+      volumes:
+      - emptyDir: {}
+        name: tmpfs-service-tmpfs-tmp
+status: {}


### PR DESCRIPTION
Especially when deploying to OpenShift, it is necessary to mount an (ephemeral) emptyDir volume at various places in the file system, to allow a process to write temporary data albeit running under a random user ID.

This commit adds support to define emptyDir volumes using Docker Compose's tmpfs feature [1].

[1]: https://docs.docker.com/reference/compose-file/services/#tmpfs

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
