### PR TITLE
chore: Only build commonly used binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 # Goreleaser
 /dist/
 /.github/release-notes.md
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,24 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+builds:
+  - id: k8ify
+    env:
+      - CGO_ENABLED=0
+    tags:
+      - netgo
+    ldflags:
+      - -s -w -extldflags "-static"
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
The default configuration of goreleaser builds windows and 32-bit variants of the binary.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog