### PR TITLE
fix: Set `serviceName` on StatefulSets

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -240,6 +240,10 @@ metadata:
 spec:
   # `services.$name.deploy.replicas`, defaults to `nil`
   replicas: 2
+  # If singleton or no `ref` given: "$name"
+  # Otherwise: "$name-$refSlug"
+  # Make sure you expose at least one port to make sure the service is created!
+  serviceName: "myapp-feat-foo"  # or "myapp"
   template:
     metadata:
       annotations:

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -237,8 +237,9 @@ func composeServiceToStatefulSet(
 	)
 
 	statefulset.Spec = apps.StatefulSetSpec{
-		Replicas: composeServiceToReplicas(workload.AsCompose()),
-		Template: templateSpec,
+		ServiceName: workload.Name + refSlug,
+		Replicas:    composeServiceToReplicas(workload.AsCompose()),
+		Template:    templateSpec,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: labels,
 		},

--- a/tests/golden/demo/manifests/mongo-statefulset.yaml
+++ b/tests/golden/demo/manifests/mongo-statefulset.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     matchLabels:
       k8ify.service: mongo
-  serviceName: ""
+  serviceName: mongo
   template:
     metadata:
       annotations:

--- a/tests/golden/parts/manifests/mongo-statefulset.yaml
+++ b/tests/golden/parts/manifests/mongo-statefulset.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       k8ify.service: mongo
-  serviceName: ""
+  serviceName: mongo
   template:
     metadata:
       creationTimestamp: null

--- a/tests/golden/storage-encrypted/manifests/default-oasp-statefulset.yaml
+++ b/tests/golden/storage-encrypted/manifests/default-oasp-statefulset.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       k8ify.ref-slug: oasp
       k8ify.service: default
-  serviceName: ""
+  serviceName: default-oasp
   template:
     metadata:
       creationTimestamp: null

--- a/tests/golden/storage-encrypted/manifests/singleton-db-statefulset.yaml
+++ b/tests/golden/storage-encrypted/manifests/singleton-db-statefulset.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       k8ify.service: singleton-db
-  serviceName: ""
+  serviceName: singleton-db
   template:
     metadata:
       creationTimestamp: null

--- a/tests/golden/storage/manifests/default-oasp-statefulset.yaml
+++ b/tests/golden/storage/manifests/default-oasp-statefulset.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       k8ify.ref-slug: oasp
       k8ify.service: default
-  serviceName: ""
+  serviceName: default-oasp
   template:
     metadata:
       creationTimestamp: null

--- a/tests/golden/storage/manifests/singleton-db-statefulset.yaml
+++ b/tests/golden/storage/manifests/singleton-db-statefulset.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       k8ify.service: singleton-db
-  serviceName: ""
+  serviceName: singleton-db
   template:
     metadata:
       creationTimestamp: null


### PR DESCRIPTION
In order for pods in a STS to "know" their FQDN (instead of just their hostname), the `spec.serviceName` attribute must be set. This will configure their FQDN to be
`${metadata.name}.${spec.serviceName}.${metadata.namespace}.svc.cluster.local`

One example where this is needed is when deploying a MongoDB Replicaset; Pods can only communicate with each other via the FQDN, not their hostnames alone; but they won't recognize "themselves" in the member list when they aren't aware of their own FQDN.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.