### PR TITLE
POC service lifecycle hooks

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func Main(args []string) int {
 	for _, shellEnvFile := range shellEnvFiles.Values {
 		err := godotenv.Load(shellEnvFile)
 		if err != nil {
-			logrus.Error(err)
+			logrus.Errorf("Loading dotfiles: %s", err)
 			return 1
 		}
 	}
@@ -96,12 +96,9 @@ func Main(args []string) int {
 		ConfigFiles: composeConfigFiles,
 		Environment: env,
 	}
-	project, err := composeLoader.LoadWithContext(context.Background(), configDetails, func(options *composeLoader.Options) {
-		// TODO: find better solution than hardcoding
-		options.SetProjectName(`k8ify`, false)
-	})
+	project, err := composeLoader.LoadWithContext(context.Background(), configDetails, func(opts *composeLoader.Options) { opts.SetProjectName("k8ify", true) })
 	if err != nil {
-		logrus.Error(err)
+		logrus.Errorf("Loading compose configuration: %s", err)
 		return 1
 	}
 
@@ -125,7 +122,7 @@ func Main(args []string) int {
 
 	err = internal.WriteManifests(config.OutputDir, objects)
 	if err != nil {
-		logrus.Error(err)
+		logrus.Errorf("Writing manifests: %s", err)
 		return 1
 	}
 

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func Main(args []string) int {
 	for _, shellEnvFile := range shellEnvFiles.Values {
 		err := godotenv.Load(shellEnvFile)
 		if err != nil {
-			logrus.Errorf("Loading dotfiles: %s", err)
+			logrus.Error(err)
 			return 1
 		}
 	}
@@ -96,9 +96,12 @@ func Main(args []string) int {
 		ConfigFiles: composeConfigFiles,
 		Environment: env,
 	}
-	project, err := composeLoader.LoadWithContext(context.Background(), configDetails, func(opts *composeLoader.Options) { opts.SetProjectName("k8ify", true) })
+	project, err := composeLoader.LoadWithContext(context.Background(), configDetails, func(options *composeLoader.Options) {
+		// TODO: find better solution than hardcoding
+		options.SetProjectName(`k8ify`, false)
+	})
 	if err != nil {
-		logrus.Errorf("Loading compose configuration: %s", err)
+		logrus.Error(err)
 		return 1
 	}
 
@@ -122,7 +125,7 @@ func Main(args []string) int {
 
 	err = internal.WriteManifests(config.OutputDir, objects)
 	if err != nil {
-		logrus.Errorf("Writing manifests: %s", err)
+		logrus.Error(err)
 		return 1
 	}
 

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -767,12 +767,12 @@ func CallExternalConverter(resourceName string, options map[string]string) (unst
 		for _, line := range strings.Split(string(output), "\n") {
 			logrus.Error(line)
 		}
-		return unstructured.Unstructured{}, fmt.Errorf("Could not convert service '%s' using command '%s': %w", resourceName, options["cmd"], err)
+		return unstructured.Unstructured{}, fmt.Errorf("could not convert service '%s' using command '%s': %w", resourceName, options["cmd"], err)
 	}
 	otherResource := unstructured.Unstructured{}
 	err = yaml.Unmarshal(output, &otherResource)
 	if err != nil {
-		return unstructured.Unstructured{}, fmt.Errorf("Could not convert service '%s' using command '%s': %w", resourceName, options["cmd"], err)
+		return unstructured.Unstructured{}, fmt.Errorf("could not convert service '%s' using command '%s': %w", resourceName, options["cmd"], err)
 	}
 	return otherResource, nil
 }

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -383,6 +383,7 @@ func composeServiceToContainer(
 	volumeMounts = append(volumeMounts, emptyDirVolumeMounts...)
 
 	livenessProbe, readinessProbe, startupProbe := composeServiceToProbes(workload)
+	lifecycle := composeServiceToLifecycle(workload)
 	containerPorts := composeServicePortsToK8sContainerPorts(workload)
 	resources := composeServiceToResourceRequirements(composeService)
 	secret := composeServiceToSecret(workload, refSlug, labels)
@@ -434,6 +435,7 @@ func composeServiceToContainer(
 		EnvFrom:         envFrom,
 		Env:             env,
 		VolumeMounts:    volumeMounts,
+		Lifecycle:       lifecycle,
 		LivenessProbe:   livenessProbe,
 		ReadinessProbe:  readinessProbe,
 		StartupProbe:    startupProbe,
@@ -680,6 +682,26 @@ func composeServiceToProbes(workload *ir.Service) (*core.Probe, *core.Probe, *co
 	return livenessProbe, readinessProbe, startupProbe
 }
 
+func composeServiceToLifecycle(workload *ir.Service) *core.Lifecycle {
+	composeService := workload.AsCompose()
+	if len(composeService.PreStop) == 0 {
+		return nil
+	}
+	if len(composeService.PreStop) > 1 {
+		return nil
+	}
+
+	cmd := composeService.PreStop[0]
+
+	return &core.Lifecycle{
+		PreStop: &core.LifecycleHandler{
+			Exec: &core.ExecAction{
+				Command: cmd.Command,
+			},
+		},
+	}
+}
+
 func composeServiceToResourceRequirements(composeService composeTypes.ServiceConfig) core.ResourceRequirements {
 	requestsMap := core.ResourceList{}
 	limitsMap := core.ResourceList{}
@@ -687,7 +709,7 @@ func composeServiceToResourceRequirements(composeService composeTypes.ServiceCon
 	if composeService.Deploy != nil {
 		if composeService.Deploy.Resources.Reservations != nil {
 			// NanoCPU appears to be a misnomer, it's actually a float indicating the number of CPU cores, nothing 'nano'
-			cpuRequest := composeService.Deploy.Resources.Reservations.NanoCPUs
+			cpuRequest := composeService.Deploy.Resources.Reservations.NanoCPUs.Value()
 			if cpuRequest > 0 {
 				requestsMap["cpu"] = resource.MustParse(fmt.Sprintf("%f", cpuRequest))
 				limitsMap["cpu"] = resource.MustParse(fmt.Sprintf("%f", cpuRequest*10.0))
@@ -701,7 +723,7 @@ func composeServiceToResourceRequirements(composeService composeTypes.ServiceCon
 		if composeService.Deploy.Resources.Limits != nil {
 			// If there are explicit limits configured we ignore the defaults calculated from the requests
 			limitsMap = core.ResourceList{}
-			cpuLimit := composeService.Deploy.Resources.Limits.NanoCPUs
+			cpuLimit := composeService.Deploy.Resources.Limits.NanoCPUs.Value()
 			if cpuLimit > 0 {
 				limitsMap["cpu"] = resource.MustParse(fmt.Sprintf("%f", cpuLimit))
 			}
@@ -745,12 +767,12 @@ func CallExternalConverter(resourceName string, options map[string]string) (unst
 		for _, line := range strings.Split(string(output), "\n") {
 			logrus.Error(line)
 		}
-		return unstructured.Unstructured{}, fmt.Errorf("could not convert service '%s' using command '%s': %w", resourceName, options["cmd"], err)
+		return unstructured.Unstructured{}, fmt.Errorf("Could not convert service '%s' using command '%s': %w", resourceName, options["cmd"], err)
 	}
 	otherResource := unstructured.Unstructured{}
 	err = yaml.Unmarshal(output, &otherResource)
 	if err != nil {
-		return unstructured.Unstructured{}, fmt.Errorf("could not convert service '%s' using command '%s': %w", resourceName, options["cmd"], err)
+		return unstructured.Unstructured{}, fmt.Errorf("Could not convert service '%s' using command '%s': %w", resourceName, options["cmd"], err)
 	}
 	return otherResource, nil
 }
@@ -933,9 +955,9 @@ type Objects struct {
 	Others                 []unstructured.Unstructured
 }
 
-func (o Objects) Append(other Objects) Objects {
+func (this Objects) Append(other Objects) Objects {
 	// Merge PVCs while avoiding duplicates based on the name
-	pvcs := o.PersistentVolumeClaims
+	pvcs := this.PersistentVolumeClaims
 	nameSet := make(map[string]bool)
 	for _, pvc := range pvcs {
 		nameSet[pvc.Name] = true
@@ -948,13 +970,13 @@ func (o Objects) Append(other Objects) Objects {
 	}
 
 	return Objects{
-		Deployments:            append(o.Deployments, other.Deployments...),
-		StatefulSets:           append(o.StatefulSets, other.StatefulSets...),
-		Services:               append(o.Services, other.Services...),
+		Deployments:            append(this.Deployments, other.Deployments...),
+		StatefulSets:           append(this.StatefulSets, other.StatefulSets...),
+		Services:               append(this.Services, other.Services...),
 		PersistentVolumeClaims: pvcs,
-		Secrets:                append(o.Secrets, other.Secrets...),
-		Ingresses:              append(o.Ingresses, other.Ingresses...),
-		PodDisruptionBudgets:   append(o.PodDisruptionBudgets, other.PodDisruptionBudgets...),
-		Others:                 append(o.Others, other.Others...),
+		Secrets:                append(this.Secrets, other.Secrets...),
+		Ingresses:              append(this.Ingresses, other.Ingresses...),
+		PodDisruptionBudgets:   append(this.PodDisruptionBudgets, other.PodDisruptionBudgets...),
+		Others:                 append(this.Others, other.Others...),
 	}
 }

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -955,9 +955,9 @@ type Objects struct {
 	Others                 []unstructured.Unstructured
 }
 
-func (this Objects) Append(other Objects) Objects {
+func (o Objects) Append(other Objects) Objects {
 	// Merge PVCs while avoiding duplicates based on the name
-	pvcs := this.PersistentVolumeClaims
+	pvcs := o.PersistentVolumeClaims
 	nameSet := make(map[string]bool)
 	for _, pvc := range pvcs {
 		nameSet[pvc.Name] = true
@@ -970,13 +970,13 @@ func (this Objects) Append(other Objects) Objects {
 	}
 
 	return Objects{
-		Deployments:            append(this.Deployments, other.Deployments...),
-		StatefulSets:           append(this.StatefulSets, other.StatefulSets...),
-		Services:               append(this.Services, other.Services...),
+		Deployments:            append(o.Deployments, other.Deployments...),
+		StatefulSets:           append(o.StatefulSets, other.StatefulSets...),
+		Services:               append(o.Services, other.Services...),
 		PersistentVolumeClaims: pvcs,
-		Secrets:                append(this.Secrets, other.Secrets...),
-		Ingresses:              append(this.Ingresses, other.Ingresses...),
-		PodDisruptionBudgets:   append(this.PodDisruptionBudgets, other.PodDisruptionBudgets...),
-		Others:                 append(this.Others, other.Others...),
+		Secrets:                append(o.Secrets, other.Secrets...),
+		Ingresses:              append(o.Ingresses, other.Ingresses...),
+		PodDisruptionBudgets:   append(o.PodDisruptionBudgets, other.PodDisruptionBudgets...),
+		Others:                 append(o.Others, other.Others...),
 	}
 }

--- a/tests/golden/pre-stop.yml
+++ b/tests/golden/pre-stop.yml
@@ -1,0 +1,3 @@
+---
+environments:
+  prod: {}

--- a/tests/golden/pre-stop/compose.yml
+++ b/tests/golden/pre-stop/compose.yml
@@ -1,0 +1,7 @@
+services:
+  nginx:
+    image: docker.io/library/nginx
+    ports:
+      - '8080:80'
+    pre_stop:
+      - command: ["/bin/sh", "echo", "\"shutting down....\""]

--- a/tests/golden/pre-stop/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/pre-stop/manifests/nginx-oasp-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        k8ify.ref-slug: oasp
+        k8ify.service: nginx
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8ify.service
+                operator: In
+                values:
+                - nginx
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: docker.io/library/nginx
+        imagePullPolicy: Always
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - echo
+              - '"shutting down...."'
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+        name: nginx-oasp
+        ports:
+        - containerPort: 80
+        resources: {}
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+      enableServiceLinks: false
+      restartPolicy: Always
+status: {}

--- a/tests/golden/pre-stop/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/pre-stop/manifests/nginx-oasp-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 80
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+status:
+  loadBalancer: {}


### PR DESCRIPTION
## Summary

Currently **only** implements command pre_stop lifecycle hook.
https://docs.docker.com/compose/how-tos/lifecycle/

Needed an updated `compose-spec/compose-go` version, as lifecycles weren't part of v1 compose-spec. It was introduced with v2.3.0.

## Breaking changes
The new v2 compose-spec requires a project name. For POC it is currently hard-coded.

Other than that:
- Only minor changes were needed due to the upgrade, only converter.go's `composeServiceToResourceRequirements` access to `NanoCPUs` changed.

## Checklist

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Added new test, could / should be extended once more lifecycle hooks are supported.
- [ ] Link this PR to related issues.
