### PR TITLE
validate max one partOf

### DIFF
--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -529,9 +529,6 @@ func composeServiceToServiceMonitors(refSlug string, workload *ir.Service, servi
 			endpoints = append(endpoints, monitorEndpoint)
 			secrets = append(secrets, partSecrets...)
 		}
-		if len(part.GetParts()) != 0 {
-			logrus.Warnf("Detected recursive partOf structure. ServiceMonitors cannot be emitted for recursive partOf structures.")
-		}
 	}
 	for i := range secrets {
 		secrets[i].TypeMeta = metav1.TypeMeta{

--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -54,7 +54,7 @@ func FromCompose(project *composeTypes.Project) *Inputs {
 
 		if partOfServiceConf, exists := project.Services[*partOf]; exists {
 			recursivePart := *(util.PartOf(partOfServiceConf.Labels))
-			logrus.Errorf("Service %s is configured to be partOf Service %s, but Service %s already is partOf Service %s, This is not supported. Please annotate Service %s to be partOf Service %s to have all of them in one pod",
+			logrus.Errorf("Service %s is configured to be partOf Service %s, but Service %s already is partOf Service %s. This is not supported. Please annotate Service %s to be partOf Service %s to have all of them in one pod.",
 				composeService.Name,
 				*partOf,
 				*partOf,

--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -49,14 +49,15 @@ func FromCompose(project *composeTypes.Project) *Inputs {
 			service := NewService(composeService.Name, composeService)
 			parent.AddPart(service)
 		} else {
+			recursivePart := *(util.PartOf(project.Services[*partOf].Labels))
 			log.Fatalf("Service %s is configured to be partOf Service %s, but Service %s already is partOf Service %s, This is not supported. Please annotate Service %s to be partOf Service %s to have all of them in one pod",
 				composeService.Name,
-				*partOf, //TODO: test if * is needed before
-				*(util.PartOf(project.Services[*partOf].Labels)), //TODO: test if this gets the correct value and make it a variable before
+				*partOf,
+				*partOf,
+				recursivePart,
 				composeService.Name,
-				*(util.PartOf(project.Services[*partOf].Labels)),
+				recursivePart,
 			)
-			//return errors.New("") //TODO: adjust return type and handle error case where this is called
 		}
 	}
 

--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -1,9 +1,8 @@
 package ir
 
 import (
-	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
+	"log"
 	"strconv"
 	"strings"
 
@@ -50,14 +49,14 @@ func FromCompose(project *composeTypes.Project) *Inputs {
 			service := NewService(composeService.Name, composeService)
 			parent.AddPart(service)
 		} else {
-			logrus.Errorf("Service %s is configured to be partOf Service %s, but Service %s already is partOf Service %s, This is not supported. Please annotate Service %s to be partOf Service %s to have all of them in one pod",
+			log.Fatalf("Service %s is configured to be partOf Service %s, but Service %s already is partOf Service %s, This is not supported. Please annotate Service %s to be partOf Service %s to have all of them in one pod",
 				composeService.Name,
 				*partOf, //TODO: test if * is needed before
 				*(util.PartOf(project.Services[*partOf].Labels)), //TODO: test if this gets the correct value and make it a variable before
 				composeService.Name,
 				*(util.PartOf(project.Services[*partOf].Labels)),
 			)
-			return errors.New("") //TODO: adjust return type and handle error case where this is called
+			//return errors.New("") //TODO: adjust return type and handle error case where this is called
 		}
 	}
 

--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -1,7 +1,9 @@
 package ir
 
 import (
+	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 
@@ -47,6 +49,15 @@ func FromCompose(project *composeTypes.Project) *Inputs {
 		if ok {
 			service := NewService(composeService.Name, composeService)
 			parent.AddPart(service)
+		} else {
+			logrus.Errorf("Service %s is configured to be partOf Service %s, but Service %s already is partOf Service %s, This is not supported. Please annotate Service %s to be partOf Service %s to have all of them in one pod",
+				composeService.Name,
+				*partOf, //TODO: test if * is needed before
+				*(util.PartOf(project.Services[*partOf].Labels)), //TODO: test if this gets the correct value and make it a variable before
+				composeService.Name,
+				*(util.PartOf(project.Services[*partOf].Labels)),
+			)
+			return errors.New("") //TODO: adjust return type and handle error case where this is called
 		}
 	}
 

--- a/tests/golden/service-monitor/compose.yml
+++ b/tests/golden/service-monitor/compose.yml
@@ -30,13 +30,6 @@ services:
     labels:
       k8ify.partOf: website-with-sidecar
       k8ify.prometheus.serviceMonitor: true
-  sidecar-of-sidecar:
-    image: docker.io/library/nginx
-    ports:
-      - '8085:80'
-    labels:
-      k8ify.partOf: sidecar
-      k8ify.prometheus.serviceMonitor: true
   website-with-empty-string-values:
     image: docker.io/library/nginx
     ports:


### PR DESCRIPTION
## Summary

* When a service with a partOf annotation referenced a service with an additional partOf annotation, the implementation never worked. It is not intended to have multiple layers of partOf. Therefore, a validation has been put in place to clearly log what is wrong and stop execution.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
