### PR TITLE
Allow specifying compose files via --file and COMPOSE_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,35 @@ This results in flexibility to support various modes of deployment, be it plain 
 
 - Argument #1: `environment`. Optional.
 - Argument #2: `ref`. Optional.
+- `-f, --file [FILE]`: Compose file to use instead of automatic discovery. Optional, repeatable to merge multiple files. Takes precedence over the `COMPOSE_FILE` environment variable.
 - `--modified-image [IMAGE]`: IMAGE has changed. Optional, repeatable.
 - `--shell-env-file [FILENAME]`: Load additional shell environment variables from file. Optional, repeatable.
+
+##### `--file` / `COMPOSE_FILE` - Specifying the Compose files
+
+By default `k8ify` discovers Compose files in the current working directory (see [`environment`](#environment)). You can point `k8ify` at Compose files in any location — overriding the discovery — either with the `-f`/`--file` flag or via the `COMPOSE_FILE` environment variable.
+
+The `--file` flag can be repeated to merge multiple files (mirroring the `docker compose -f` behaviour):
+
+```console
+k8ify prod --file path/to/compose.yml --file path/to/compose-prod.yml
+```
+
+Equivalently, the `COMPOSE_FILE` environment variable lists one or more Compose files. Multiple files are separated by the `COMPOSE_PATH_SEPARATOR` environment variable, which defaults to the OS path list separator (`:` on Linux/macOS, `;` on Windows):
+
+```console
+COMPOSE_FILE=path/to/compose.yml:path/to/compose-prod.yml k8ify prod
+```
+
+When both are set, the `--file` flag takes precedence over `COMPOSE_FILE`. When neither is set, the automatic discovery is used.
+
+Independently of how the base files were selected, `k8ify` always looks for an environment specific override derived from every base file and merges it on top. The override is found next to its base file by inserting `-<env>` immediately before the extension (e.g. `compose.yml` with env `prod` becomes `compose-prod.yml`, `path/to/compose.yml` becomes `path/to/compose-prod.yml`). An override file that does not exist on disk is silently skipped, so it is enough to list only the base file:
+
+```console
+k8ify prod --file path/to/compose.yml
+```
+
+This loads both `path/to/compose.yml` and `path/to/compose-prod.yml` (the latter overriding the former). Listing an override file explicitly (e.g. via an additional `--file path/to/compose-prod.yml`) is also fine — `k8ify` will not load it twice — which lets you pin the exact set and order of files when needed.
 
 #### `environment`
 

--- a/golden_test.go
+++ b/golden_test.go
@@ -26,6 +26,11 @@ var (
 
 type Instance struct {
 	Environments map[string]Environment `yaml:"environments"`
+	// Flag is an optional top-level config whose params are merged into every environment.
+	Flag Environment `yaml:"flag"`
+	// Env is an optional top-level config whose vars are merged into every environment
+	// (environment-specific vars take precedence over these).
+	Env Environment `yaml:"env"`
 }
 
 type Environment struct {
@@ -87,8 +92,21 @@ func testInstance(t *testing.T, instanceFile string) {
 	check(os.Chdir(root), "changing working directory")
 
 	for name, env := range i.Environments {
+		// Merge top-level flag params and env vars into the environment.
+		// Environment-specific values take precedence over top-level ones.
+		merged := Environment{
+			Refs:   env.Refs,
+			Params: append(append([]string{}, i.Flag.Params...), env.Params...),
+			Vars:   make(map[string]string, len(i.Env.Vars)+len(env.Vars)),
+		}
+		for k, v := range i.Env.Vars {
+			merged.Vars[k] = v
+		}
+		for k, v := range env.Vars {
+			merged.Vars[k] = v
+		}
 		t.Run(name, func(t *testing.T) {
-			testEnvironment(t, name, env)
+			testEnvironment(t, name, merged)
 		})
 	}
 

--- a/internal/cmdflags.go
+++ b/internal/cmdflags.go
@@ -38,6 +38,24 @@ func (f *ShellEnvFilesFlag) Type() string {
 	return ".env"
 }
 
+// StringSliceFlag implements pflag.Value for a repeatable string flag.
+type StringSliceFlag struct {
+	Values []string
+}
+
+func (f *StringSliceFlag) Set(value string) error {
+	f.Values = append(f.Values, value)
+	return nil
+}
+
+func (f *StringSliceFlag) String() string {
+	return fmt.Sprintf("%v", f.Values)
+}
+
+func (f *StringSliceFlag) Type() string {
+	return "stringSlice"
+}
+
 type ProviderFlag struct {
 	value string
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	composeLoader "github.com/compose-spec/compose-go/v2/loader"
@@ -26,6 +28,7 @@ var (
 	}
 	modifiedImages   internal.ModifiedImagesFlag
 	shellEnvFiles    internal.ShellEnvFilesFlag
+	composeFiles     internal.StringSliceFlag
 	pflagInitialized = false
 )
 
@@ -34,6 +37,7 @@ func InitPflag() {
 	if !pflagInitialized {
 		pflag.Var(&modifiedImages, "modified-image", "Image that has been modified during the build. Can be repeated.")
 		pflag.Var(&shellEnvFiles, "shell-env-file", "Shell environment file ('key=value' format) to be used in addition to the current shell environment. Can be repeated.")
+		pflag.VarP(&composeFiles, "file", "f", "Compose file to convert instead of the automatic discovery. Can be repeated to merge multiple files, like 'docker compose -f'. Takes precedence over the COMPOSE_FILE environment variable. For each file an environment specific override is also loaded by inserting '-<env>' before the extension (e.g. compose-prod.yml for compose.yml with env prod), so listing only the base file is enough.\n\nThe COMPOSE_FILE environment variable offers the same selection when the flag is not set. It lists one or more files separated by the COMPOSE_PATH_SEPARATOR variable (defaulting to the OS path list separator, ':' on Linux/macOS, ';' on Windows).")
 		pflagInitialized = true
 	}
 }
@@ -45,6 +49,10 @@ func main() {
 
 func Main(args []string) int {
 	InitPflag()
+	// Reset flag state so that repeated invocations (e.g. from tests) don't accumulate values from previous runs.
+	modifiedImages.Values = nil
+	shellEnvFiles.Values = nil
+	composeFiles.Values = nil
 	err := pflag.CommandLine.Parse(args[1:])
 	if err != nil {
 		logrus.Error(err)
@@ -60,18 +68,32 @@ func Main(args []string) int {
 		config.Ref = plainArgs[1]
 	}
 
-	if len(config.ConfigFiles) == 0 {
-		config.ConfigFiles = []string{"compose.yml", "docker-compose.yml", "compose-" + config.Env + ".yml", "docker-compose-" + config.Env + ".yml"}
-	}
-
-	// Load the additional shell environment files. This will merge everything into the existing shell environment and
-	// all values can later be retrieved using os.Environ()
+	// Load the additional shell environment files first. This merges everything into the existing shell environment
+	// (retrievable via os.Environ()) so that variables defined there - e.g. COMPOSE_FILE - are available below.
 	for _, shellEnvFile := range shellEnvFiles.Values {
 		err := godotenv.Load(shellEnvFile)
 		if err != nil {
 			logrus.Errorf("Loading dotfiles: %s", err)
 			return 1
 		}
+	}
+
+	if len(config.ConfigFiles) == 0 {
+		composeFileEnv := os.Getenv("COMPOSE_FILE")
+		switch {
+		case len(composeFiles.Values) > 0:
+			config.ConfigFiles = composeFiles.Values
+		case composeFileEnv != "":
+			separator := os.Getenv("COMPOSE_PATH_SEPARATOR")
+			if separator == "" {
+				separator = string(os.PathListSeparator)
+			}
+			config.ConfigFiles = strings.Split(composeFileEnv, separator)
+		default:
+			config.ConfigFiles = []string{"compose.yml", "docker-compose.yml"}
+		}
+
+		config.ConfigFiles = appendDeduplicatedEnvOverridesInOrder(config.ConfigFiles, config.Env)
 	}
 
 	composeConfigFiles := []composeTypes.ConfigFile{}
@@ -127,4 +149,27 @@ func Main(args []string) int {
 	}
 
 	return 0
+}
+
+func appendDeduplicatedEnvOverridesInOrder(files []string, env string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+
+	add := func(f string) {
+		if _, ok := seen[f]; !ok {
+			seen[f] = struct{}{}
+			out = append(out, f)
+		}
+	}
+
+	for _, f := range files {
+		add(f)
+		add(envOverrideName(f, env))
+	}
+	return out
+}
+
+func envOverrideName(file, env string) string {
+	ext := filepath.Ext(file)
+	return strings.TrimSuffix(file, ext) + "-" + env + ext
 }

--- a/tests/golden/compose-file-env-variable.yml
+++ b/tests/golden/compose-file-env-variable.yml
@@ -1,0 +1,6 @@
+---
+environments:
+  prod: {}
+env:
+  vars:
+    COMPOSE_FILE: "config/compose.yml:config/compose-other.yml"

--- a/tests/golden/compose-file-env-variable/config/compose-other.yml
+++ b/tests/golden/compose-file-env-variable/config/compose-other.yml
@@ -1,0 +1,8 @@
+services:
+  nginx:
+    deploy:
+      replicas: 2
+      resources:
+        reservations:
+          cpus: "0.2"
+          memory: 256M

--- a/tests/golden/compose-file-env-variable/config/compose.yml
+++ b/tests/golden/compose-file-env-variable/config/compose.yml
@@ -1,0 +1,5 @@
+services:
+  nginx:
+    image: docker.io/library/nginx
+    ports:
+      - '8080:80'

--- a/tests/golden/compose-file-env-variable/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/compose-file-env-variable/manifests/nginx-oasp-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        k8ify.ref-slug: oasp
+        k8ify.service: nginx
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8ify.service
+                operator: In
+                values:
+                - nginx
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: docker.io/library/nginx
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+        name: nginx-oasp
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: "2"
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+      enableServiceLinks: false
+      restartPolicy: Always
+status: {}

--- a/tests/golden/compose-file-env-variable/manifests/nginx-oasp-poddisruptionbudget.yaml
+++ b/tests/golden/compose-file-env-variable/manifests/nginx-oasp-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  maxUnavailable: 50%
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/tests/golden/compose-file-env-variable/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/compose-file-env-variable/manifests/nginx-oasp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 80
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+status:
+  loadBalancer: {}

--- a/tests/golden/compose-file-flag-precedence.yml
+++ b/tests/golden/compose-file-flag-precedence.yml
@@ -1,0 +1,8 @@
+---
+environments:
+  prod: {}
+flag:
+  params: ["--file", "config/compose.yml", "--file", "config/compose-prod.yml"]
+env:
+  vars:
+    COMPOSE_FILE: "config/compose.yml"

--- a/tests/golden/compose-file-flag-precedence/config/compose-prod.yml
+++ b/tests/golden/compose-file-flag-precedence/config/compose-prod.yml
@@ -1,0 +1,8 @@
+services:
+  nginx:
+    deploy:
+      replicas: 2
+      resources:
+        reservations:
+          cpus: "0.2"
+          memory: 256M

--- a/tests/golden/compose-file-flag-precedence/config/compose.yml
+++ b/tests/golden/compose-file-flag-precedence/config/compose.yml
@@ -1,0 +1,5 @@
+services:
+  nginx:
+    image: docker.io/library/nginx
+    ports:
+      - '8080:80'

--- a/tests/golden/compose-file-flag-precedence/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/compose-file-flag-precedence/manifests/nginx-oasp-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        k8ify.ref-slug: oasp
+        k8ify.service: nginx
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8ify.service
+                operator: In
+                values:
+                - nginx
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: docker.io/library/nginx
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+        name: nginx-oasp
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: "2"
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+      enableServiceLinks: false
+      restartPolicy: Always
+status: {}

--- a/tests/golden/compose-file-flag-precedence/manifests/nginx-oasp-poddisruptionbudget.yaml
+++ b/tests/golden/compose-file-flag-precedence/manifests/nginx-oasp-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  maxUnavailable: 50%
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/tests/golden/compose-file-flag-precedence/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/compose-file-flag-precedence/manifests/nginx-oasp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 80
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+status:
+  loadBalancer: {}

--- a/tests/golden/compose-file-flag.yml
+++ b/tests/golden/compose-file-flag.yml
@@ -1,0 +1,5 @@
+---
+environments:
+  dev: {}
+flag:
+  params: ["--file", "config/compose.yml", "--file", "config/compose-other.yml"]

--- a/tests/golden/compose-file-flag/config/compose-other.yml
+++ b/tests/golden/compose-file-flag/config/compose-other.yml
@@ -1,0 +1,8 @@
+services:
+  nginx:
+    deploy:
+      replicas: 2
+      resources:
+        reservations:
+          cpus: "0.2"
+          memory: 256M

--- a/tests/golden/compose-file-flag/config/compose.yml
+++ b/tests/golden/compose-file-flag/config/compose.yml
@@ -1,0 +1,5 @@
+services:
+  nginx:
+    image: docker.io/library/nginx
+    ports:
+      - '8080:80'

--- a/tests/golden/compose-file-flag/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/compose-file-flag/manifests/nginx-oasp-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        k8ify.ref-slug: oasp
+        k8ify.service: nginx
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8ify.service
+                operator: In
+                values:
+                - nginx
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: docker.io/library/nginx
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+        name: nginx-oasp
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: "2"
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+      enableServiceLinks: false
+      restartPolicy: Always
+status: {}

--- a/tests/golden/compose-file-flag/manifests/nginx-oasp-poddisruptionbudget.yaml
+++ b/tests/golden/compose-file-flag/manifests/nginx-oasp-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  maxUnavailable: 50%
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/tests/golden/compose-file-flag/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/compose-file-flag/manifests/nginx-oasp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 80
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+status:
+  loadBalancer: {}

--- a/tests/golden/compose-file-with-environment.yml
+++ b/tests/golden/compose-file-with-environment.yml
@@ -1,0 +1,5 @@
+---
+environments:
+  prod: {}
+flag:
+  params: ["--file", "config/compose.yml"]

--- a/tests/golden/compose-file-with-environment/config/compose-prod.yml
+++ b/tests/golden/compose-file-with-environment/config/compose-prod.yml
@@ -1,0 +1,8 @@
+services:
+  nginx:
+    deploy:
+      replicas: 2
+      resources:
+        reservations:
+          cpus: "0.2"
+          memory: 256M

--- a/tests/golden/compose-file-with-environment/config/compose.yml
+++ b/tests/golden/compose-file-with-environment/config/compose.yml
@@ -1,0 +1,5 @@
+services:
+  nginx:
+    image: docker.io/library/nginx
+    ports:
+      - '8080:80'

--- a/tests/golden/compose-file-with-environment/manifests/nginx-oasp-deployment.yaml
+++ b/tests/golden/compose-file-with-environment/manifests/nginx-oasp-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        k8ify.ref-slug: oasp
+        k8ify.service: nginx
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8ify.service
+                operator: In
+                values:
+                - nginx
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: docker.io/library/nginx
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          periodSeconds: 30
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+        name: nginx-oasp
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: "2"
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 80
+          timeoutSeconds: 60
+      enableServiceLinks: false
+      restartPolicy: Always
+status: {}

--- a/tests/golden/compose-file-with-environment/manifests/nginx-oasp-poddisruptionbudget.yaml
+++ b/tests/golden/compose-file-with-environment/manifests/nginx-oasp-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  maxUnavailable: 50%
+  selector:
+    matchLabels:
+      k8ify.ref-slug: oasp
+      k8ify.service: nginx
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/tests/golden/compose-file-with-environment/manifests/nginx-oasp-service.yaml
+++ b/tests/golden/compose-file-with-environment/manifests/nginx-oasp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+  name: nginx-oasp
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 80
+  selector:
+    k8ify.ref-slug: oasp
+    k8ify.service: nginx
+status:
+  loadBalancer: {}


### PR DESCRIPTION
Add the -f/--file flag and the COMPOSE_FILE environment variable as ways to select the compose files k8ify converts, taking precedence over the automatic discovery in the current working directory. The flag can be repeated to merge multiple files, mirroring `docker compose -f`, and COMPOSE_FILE accepts a list separated by COMPOSE_PATH_SEPARATOR (which defaults to the OS path list separator). The flag takes precedence over the environment variable when both are set.

Independently of how the base files were chosen, automatically discover an environment specific override next to each base file by inserting -<env> before the extension (e.g. compose-prod.yml for compose.yml with env prod) and merge it on top, so pointing k8ify at a custom base file location still picks up the matching override. Overrides already listed explicitly are deduplicated and never loaded twice, which lets users pin the exact set and order of files when needed. Describe the flag and the COMPOSE_FILE variable in the command help output and document the behaviour in the README.

Extend the golden test harness with a top-level flag and env block and add fixtures covering -f, COMPOSE_FILE, their precedence and the environment override discovery.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

