### PR TITLE
refactor: remove prometheus-operator dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/compose-spec/compose-go/v2 v2.11.0
 	github.com/docker/go-units v0.5.0
 	github.com/joho/godotenv v1.5.1
-	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -29,6 +28,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/moby/term v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/compose-spec/compose-go/v2 v2.11.0 h1:xoq/ootgIL6TsHmbJHrkuh7+bzjhPV3NHftHRPPyVXM=
 github.com/compose-spec/compose-go/v2 v2.11.0/go.mod h1:ZU6zlcweCZKyiB7BVfCizQT9XmkEIMFE+PRZydVcsZg=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -50,8 +51,6 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.2 h1:VRXUgbGmpmjZgFYiUnTwlC+JjfCUs5KKFsorJhI1ZKQ=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.2/go.mod h1:nPk0OteXBkbT0CRCa2oZQL1jRLW6RJ2fuIijHypeJdk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=

--- a/internal/output.go
+++ b/internal/output.go
@@ -89,7 +89,7 @@ func WriteManifests(outputDir string, objects converter.Objects) error {
 	logrus.Infof("wrote %d services\n", len(objects.Services))
 
 	for _, serviceMonitor := range objects.ServiceMonitors {
-		err := writeManifest(&serviceMonitor, outputDir+"/"+serviceMonitor.Name+"-servicemonitor.yaml")
+		err := writeManifest(&serviceMonitor, outputDir+"/"+serviceMonitor.GetName()+"-servicemonitor.yaml")
 		if err != nil {
 			return err
 		}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -9,9 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	prometheusTypes "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/sirupsen/logrus"
 	"github.com/vshn/k8ify/pkg/ir"
@@ -505,18 +502,18 @@ func composeServiceToServices(refSlug string, workload *ir.Service, servicePorts
 	return services
 }
 
-func composeServiceToServiceMonitors(refSlug string, workload *ir.ParentService, servicePorts []core.ServicePort, labels map[string]string) ([]ServiceMonitor, []core.Secret) {
+func composeServiceToServiceMonitors(refSlug string, workload *ir.ParentService, servicePorts []core.ServicePort, labels map[string]string) ([]unstructured.Unstructured, []core.Secret) {
 	if len(servicePorts) == 0 {
-		return []ServiceMonitor{}, []core.Secret{}
+		return []unstructured.Unstructured{}, []core.Secret{}
 	}
 	config := ir.ServiceMonitorConfigPointer(workload.Labels())
 	if config == nil {
-		return []ServiceMonitor{}, []core.Secret{}
+		return []unstructured.Unstructured{}, []core.Secret{}
 	}
 
 	resourceName := workload.Name + refSlug
 	endpoint, secrets := createServiceMonitorEndpoint(resourceName, servicePorts, config, workload.Labels())
-	endpoints := []prometheusTypes.Endpoint{endpoint}
+	endpoints := []interface{}{endpoint}
 	for _, part := range workload.GetParts() {
 		partConfig := ir.ServiceMonitorConfigPointer(part.Labels())
 		if partConfig != nil {
@@ -533,29 +530,30 @@ func composeServiceToServiceMonitors(refSlug string, workload *ir.ParentService,
 		}
 		secrets[i].Labels = labels
 	}
-	return []ServiceMonitor{
+	return []unstructured.Unstructured{
 		{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "ServiceMonitor",
-				APIVersion: "monitoring.coreos.com/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   resourceName,
-				Labels: labels,
-			},
-			Spec: prometheusTypes.ServiceMonitorSpec{
-				Endpoints: endpoints,
-				Selector: metav1.LabelSelector{
-					MatchLabels: labels,
+			Object: map[string]interface{}{
+				"apiVersion": "monitoring.coreos.com/v1",
+				"kind":       "ServiceMonitor",
+				"metadata": map[string]interface{}{
+					"name":   resourceName,
+					"labels": labels,
+				},
+				"spec": map[string]interface{}{
+					"endpoints":         endpoints,
+					"namespaceSelector": map[string]interface{}{},
+					"selector": map[string]interface{}{
+						"matchLabels": labels,
+					},
 				},
 			},
 		},
 	}, secrets
 }
 
-func createServiceMonitorEndpoint(name string, servicePorts []core.ServicePort, config *ir.ServiceMonitorConfig, labels map[string]string) (prometheusTypes.Endpoint, []core.Secret) {
+func createServiceMonitorEndpoint(name string, servicePorts []core.ServicePort, config *ir.ServiceMonitorConfig, labels map[string]string) (map[string]interface{}, []core.Secret) {
 	endpoint := createEndpointConf(config, servicePorts)
-	secretName := name + "-servicemonitor-" + endpoint.Port
+	secretName := name + "-servicemonitor-" + endpoint["port"].(string)
 	secret := core.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
@@ -564,11 +562,15 @@ func createServiceMonitorEndpoint(name string, servicePorts []core.ServicePort, 
 	}
 
 	basicAuth, basicAuthEntries := createBasicAuthForEndpoint(secretName, labels)
-	endpoint.BasicAuth = basicAuth
+	if basicAuth != nil {
+		endpoint["basicAuth"] = basicAuth
+	}
 	secret.StringData = util.AppendMap(secret.StringData, basicAuthEntries)
 
 	tlsConfig, tlsConfigEntries := createTlsConfigForEndpoint(secretName, labels)
-	endpoint.TLSConfig = tlsConfig
+	if tlsConfig != nil {
+		endpoint["tlsConfig"] = tlsConfig
+	}
 	secret.StringData = util.AppendMap(secret.StringData, tlsConfigEntries)
 
 	var secretsList []core.Secret
@@ -579,27 +581,27 @@ func createServiceMonitorEndpoint(name string, servicePorts []core.ServicePort, 
 	return endpoint, secretsList
 }
 
-func createEndpointConf(config *ir.ServiceMonitorConfig, servicePorts []core.ServicePort) prometheusTypes.Endpoint {
-	endpoint := prometheusTypes.Endpoint{
-		Interval: "30s",
-		Port:     servicePorts[0].Name,
-		Path:     "/actuator/metrics",
-		Scheme:   "http",
+func createEndpointConf(config *ir.ServiceMonitorConfig, servicePorts []core.ServicePort) map[string]interface{} {
+	endpoint := map[string]interface{}{
+		"interval": "30s",
+		"port":     servicePorts[0].Name,
+		"path":     "/actuator/metrics",
+		"scheme":   "http",
 	}
 	if config.Interval != nil {
-		endpoint.Interval = prometheusTypes.Duration(*config.Interval)
+		endpoint["interval"] = *config.Interval
 	}
 	if config.Path != nil {
-		endpoint.Path = *config.Path
+		endpoint["path"] = *config.Path
 	}
 	if config.Scheme != nil {
-		endpoint.Scheme = *config.Scheme
+		endpoint["scheme"] = *config.Scheme
 	}
 	if config.EndpointName != nil {
 		found := false
 		for _, servicePort := range servicePorts {
 			if servicePort.Name == *config.EndpointName {
-				endpoint.Port = servicePort.Name
+				endpoint["port"] = servicePort.Name
 				found = true
 				break
 			}
@@ -607,14 +609,14 @@ func createEndpointConf(config *ir.ServiceMonitorConfig, servicePorts []core.Ser
 		if !found {
 			logrus.WithFields(logrus.Fields{
 				"configuredPort": *config.EndpointName,
-				"usedPort":       endpoint.Port,
+				"usedPort":       endpoint["port"],
 			}).Warning("Port configuredPort not found, using usedPort.")
 		}
 	}
 	return endpoint
 }
 
-func createBasicAuthForEndpoint(secretName string, labels map[string]string) (*prometheusTypes.BasicAuth, map[string]string) {
+func createBasicAuthForEndpoint(secretName string, labels map[string]string) (map[string]interface{}, map[string]string) {
 	basicAuthConfig, _ := ir.ServiceMonitorBasicAuthConfigPointer(labels)
 	if basicAuthConfig == nil {
 		return nil, map[string]string{}
@@ -623,60 +625,64 @@ func createBasicAuthForEndpoint(secretName string, labels map[string]string) (*p
 		"username": basicAuthConfig.Username,
 		"password": basicAuthConfig.Password,
 	}
-	basicAuth := &prometheusTypes.BasicAuth{
-		Username: secretKeySelector(secretName, "username"),
-		Password: secretKeySelector(secretName, "password"),
+	basicAuth := map[string]interface{}{
+		"username": secretKeySelector(secretName, "username"),
+		"password": secretKeySelector(secretName, "password"),
 	}
 	return basicAuth, secretEntries
 }
 
-func createTlsConfigForEndpoint(secretName string, labels map[string]string) (*prometheusTypes.TLSConfig, map[string]string) {
+func createTlsConfigForEndpoint(secretName string, labels map[string]string) (map[string]interface{}, map[string]string) {
 	labelTlsConfig, _ := ir.ServiceMonitorTlsConfigPointer(labels)
 	if labelTlsConfig == nil {
 		return nil, map[string]string{}
 	}
 
-	safeTlsConfig := prometheusTypes.SafeTLSConfig{
-		InsecureSkipVerify: labelTlsConfig.InsecureSkipVerify,
-		MaxVersion:         labelTlsConfig.MaxVersion,
-		MinVersion:         labelTlsConfig.MinVersion,
-		ServerName:         labelTlsConfig.ServerName,
-	}
-
 	secretEntries := map[string]string{}
-	if labelTlsConfig.Ca != nil {
-		secretKey := "ca"
-		secretEntries[secretKey] = *labelTlsConfig.Ca
-		safeTlsConfig.CA = prometheusTypes.SecretOrConfigMap{
-			Secret: util.GetPointer(secretKeySelector(secretName, secretKey)),
-		}
-	}
+	tlsConfig := map[string]interface{}{}
 
-	if labelTlsConfig.Cert != nil {
-		secretKey := "cert"
-		secretEntries[secretKey] = *labelTlsConfig.Cert
-		safeTlsConfig.Cert = prometheusTypes.SecretOrConfigMap{
-			Secret: util.GetPointer(secretKeySelector(secretName, secretKey)),
-		}
+	ca := map[string]interface{}{}
+	if labelTlsConfig.Ca != nil {
+		ca["secret"] = secretKeySelector(secretName, "ca")
+		secretEntries["ca"] = *labelTlsConfig.Ca
 	}
+	tlsConfig["ca"] = ca
+
+	cert := map[string]interface{}{}
+	if labelTlsConfig.Cert != nil {
+		cert["secret"] = secretKeySelector(secretName, "cert")
+		secretEntries["cert"] = *labelTlsConfig.Cert
+	}
+	tlsConfig["cert"] = cert
 
 	if labelTlsConfig.KeySecretValue != nil {
-		secretKey := "key"
-		secretEntries[secretKey] = *labelTlsConfig.KeySecretValue
-		safeTlsConfig.KeySecret = util.GetPointer(secretKeySelector(secretName, secretKey))
+		tlsConfig["keySecret"] = secretKeySelector(secretName, "key")
+		secretEntries["key"] = *labelTlsConfig.KeySecretValue
 	}
 
-	return util.GetPointer(prometheusTypes.TLSConfig{
-		SafeTLSConfig: safeTlsConfig,
-	}), secretEntries
+	if labelTlsConfig.InsecureSkipVerify != nil {
+		tlsConfig["insecureSkipVerify"] = *labelTlsConfig.InsecureSkipVerify
+	}
+
+	if labelTlsConfig.ServerName != nil {
+		tlsConfig["serverName"] = *labelTlsConfig.ServerName
+	}
+
+	if labelTlsConfig.MinVersion != nil {
+		tlsConfig["minVersion"] = *labelTlsConfig.MinVersion
+	}
+
+	if labelTlsConfig.MaxVersion != nil {
+		tlsConfig["maxVersion"] = *labelTlsConfig.MaxVersion
+	}
+
+	return tlsConfig, secretEntries
 }
 
-func secretKeySelector(secretName string, secretKey string) core.SecretKeySelector {
-	return core.SecretKeySelector{
-		LocalObjectReference: core.LocalObjectReference{
-			Name: secretName,
-		},
-		Key: secretKey,
+func secretKeySelector(secretName string, secretKey string) map[string]interface{} {
+	return map[string]interface{}{
+		"key":  secretKey,
+		"name": secretName,
 	}
 }
 
@@ -1119,12 +1125,6 @@ func composeServiceToPodDisruptionBudget(workload *ir.Service, refSlug string, l
 	return &podDisruptionBudget
 }
 
-type ServiceMonitor prometheusTypes.ServiceMonitor
-
-func (s ServiceMonitor) DeepCopyObject() runtime.Object {
-	panic("Needed for interface runtime.Object. Not implemented because it was not used yet.")
-}
-
 // Objects combines all possible resources the conversion process could produce
 type Objects struct {
 	// Deployments
@@ -1134,7 +1134,7 @@ type Objects struct {
 	Services               []core.Service
 	PersistentVolumeClaims []core.PersistentVolumeClaim
 	Secrets                []core.Secret // You don't have to create secrets for all values. A reference is also possible with _ref_ and _secretRef_.
-	ServiceMonitors        []ServiceMonitor
+	ServiceMonitors        []unstructured.Unstructured
 	Ingresses              []networking.Ingress
 	PodDisruptionBudgets   []v1.PodDisruptionBudget
 	Others                 []unstructured.Unstructured

--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
-	prometheusTypes "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/vshn/k8ify/pkg/util"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -310,31 +309,31 @@ type ServiceMonitorTlsConfig struct {
 	Cert               *string
 	KeySecretValue     *string
 	InsecureSkipVerify *bool
-	MaxVersion         *prometheusTypes.TLSVersion
-	MinVersion         *prometheusTypes.TLSVersion
+	MaxVersion         *string
+	MinVersion         *string
 	ServerName         *string
 }
 
 var (
-	tlsVersion10 = string(prometheusTypes.TLSVersion10)
-	tlsVersion11 = string(prometheusTypes.TLSVersion11)
-	tlsVersion12 = string(prometheusTypes.TLSVersion12)
-	tlsVersion13 = string(prometheusTypes.TLSVersion13)
+	tlsVersion10 = "TLS10"
+	tlsVersion11 = "TLS11"
+	tlsVersion12 = "TLS12"
+	tlsVersion13 = "TLS13"
 )
 
-func parseTlsVersion(string *string) (*prometheusTypes.TLSVersion, error) {
+func parseTlsVersion(string *string) (*string, error) {
 	if string == nil {
 		return nil, nil
 	}
 	switch *string {
 	case tlsVersion10:
-		return util.GetPointer(prometheusTypes.TLSVersion10), nil
+		return util.GetPointer("TLS10"), nil
 	case tlsVersion11:
-		return util.GetPointer(prometheusTypes.TLSVersion11), nil
+		return util.GetPointer("TLS11"), nil
 	case tlsVersion12:
-		return util.GetPointer(prometheusTypes.TLSVersion12), nil
+		return util.GetPointer("TLS12"), nil
 	case tlsVersion13:
-		return util.GetPointer(prometheusTypes.TLSVersion13), nil
+		return util.GetPointer("TLS13"), nil
 	default:
 		return nil, fmt.Errorf("unknown TLSVersion: %v", *string)
 	}

--- a/pkg/ir/ir_test.go
+++ b/pkg/ir/ir_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	prometheusTypes "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	assertions "github.com/stretchr/testify/assert"
 	"github.com/vshn/k8ify/pkg/util"
 )
@@ -205,8 +204,8 @@ func TestServiceMonitorTlsConfig(t *testing.T) {
 				Cert:               &monitorCert,
 				KeySecretValue:     &monitorKeySecretValue,
 				InsecureSkipVerify: util.GetPointer(true),
-				MaxVersion:         util.GetPointer(prometheusTypes.TLSVersion13),
-				MinVersion:         util.GetPointer(prometheusTypes.TLSVersion10),
+				MaxVersion:         util.GetPointer("TLS13"),
+				MinVersion:         util.GetPointer("TLS10"),
 				ServerName:         &monitorServerName,
 			},
 		},
@@ -252,7 +251,7 @@ var (
 	monitorPath           = "/actuator/health"
 	monitorScheme         = "http"
 	monitorServerName     = "service.svc"
-	monitorTlsMaxVersion  = string(prometheusTypes.TLSVersion13)
-	monitorTlsMinVersion  = string(prometheusTypes.TLSVersion10)
+	monitorTlsMaxVersion  = "TLS13"
+	monitorTlsMinVersion  = "TLS10"
 	monitorUsername       = "myuser"
 )


### PR DESCRIPTION
Replace the github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring Go types with a hand-built map[string]interface{} carried by unstructured.Unstructured. The ServiceMonitor object rarely changes, so the structure is hardcoded, reproducing the prometheus types' omitempty semantics to keep the generated YAML byte-identical.

- converter: build ServiceMonitor, endpoints, basicAuth and tlsConfig as maps; drop the panicking ServiceMonitor type alias and DeepCopyObject; Objects.ServiceMonitors is now []unstructured.Unstructured
- ir: ServiceMonitorTlsConfig MaxVersion/MinVersion are now *string with hardcoded TLS10..TLS13 constants
- output: use serviceMonitor.GetName() for the unstructured object

## Summary

* Short summary of what's included in the PR
* Give special note to breaking changes

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


Done with AI.
